### PR TITLE
[#177186994] update CreditCard definition

### DIFF
--- a/bonus/specs/bpd/pm/walletv2.json
+++ b/bonus/specs/bpd/pm/walletv2.json
@@ -1081,6 +1081,16 @@
         },
         "securityCode": {
           "type": "string"
+        },
+        "productType": {
+          "type": "string",
+          "description": "TMP draft for develop, to be confirmed",
+          "enum": [
+            "CREDIT",
+            "PREPAID",
+            "DEBIT",
+            "PRIVATIVE"
+          ]
         }
       },
       "title": "CreditCard"


### PR DESCRIPTION
This pr updates the `CreditCard` definition, in order to support the new field `productType` and identify a Privative card