### PR TITLE
[#177142050] Add pancode to pm `/v1/cobadge/pans` specification

### DIFF
--- a/bonus/specs/bpd/pm/walletv2.json
+++ b/bonus/specs/bpd/pm/walletv2.json
@@ -532,6 +532,13 @@
             "description": "abiCode",
             "required": false,
             "type": "string"
+          },
+          {
+            "name": "panCode",
+            "in": "header",
+            "description": "panCode",
+            "required": false,
+            "type": "string"
           }
         ],
         "responses": {


### PR DESCRIPTION
This pr changes the PM specification in order to support the search of privative card.