### PR TITLE
added ISP with only 1 issuer

### DIFF
--- a/status/cobadgeServices.json
+++ b/status/cobadgeServices.json
@@ -1113,5 +1113,13 @@
         "name": "Cassa Centrale Banca – Credito Cooperativo Italiano S.p.A."
       }
     ]
+  },
+  "INTESA" : {
+    "status" : "enabled",
+    "issuers" : [
+      {
+        "abi": "06225"
+      }
+    ]
   }
 }

--- a/status/cobadgeServices.json
+++ b/status/cobadgeServices.json
@@ -1118,7 +1118,8 @@
     "status" : "enabled",
     "issuers" : [
       {
-        "abi": "06225"
+        "abi": "06225",
+        "name": "CASSA DI RISPARMIO DEL VENETO"
       }
     ]
   }


### PR DESCRIPTION
new co-badge service provider  ( Intesa San Paolo ).
only 1 issuer abi (06225 - cassa di risparmio del Veneto) for testing in production.