### PR TITLE
[BSP-62] add poste italiane co-badge service

### DIFF
--- a/status/abi.json
+++ b/status/abi.json
@@ -2119,9 +2119,13 @@
     {
       "abi": "06325",
       "name": "Cassa di Risparmio di Tortona S.p.A."
+    },
+    {
+      "abi": "07601",
+      "name": "Poste Italiane S.p.A."
     }
   ],
-  "total": 530,
+  "total": 531,
   "start": 0,
-  "size": 530
+  "size": 531
 }

--- a/status/cobadgeServices.json
+++ b/status/cobadgeServices.json
@@ -1270,5 +1270,14 @@
         "name": "Cassa di Risparmio di Tortona S.p.A."
       }
     ]
+  },
+  "POSTE":{
+    "status" : "enabled",
+    "issuers" : [
+      {
+        "abi": "07601",
+        "name": "Poste Italiane S.p.A."
+      }
+    ]
   }
 }


### PR DESCRIPTION
Poste Italia SpA co-badge service.
It retrieves Postamat cards.
A PostaMat card is not valid for e-commerce and use a Mastercard or Maestro circuit