### PR TITLE
Add a sanity check for visible services webview data

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "update_indicepa": "ts-node src/update_indicepa.ts",
     "update_municipalities": "ts-node src/update_municipalities.ts",
     "update_services": "ts-node src/update_services.ts",
+    "check_services_webview_data": "ts-node src/checks/checkVisibleServicesWebView.ts",
     "check_contextual_help_data": "ts-node src/checks/checkContextualHelpData.ts",
     "check_idps_list_data": "ts-node src/checks/checkIdpsData.ts",
     "check_bonus_available_data": "ts-node src/checks/checkBonusAvailable.ts",
@@ -29,7 +30,7 @@
     "generate:pagopa-bpd-citizen-v2": "rimraf ./generated/definitions/bpd/citizenv2 && mkdir -p ./generated/definitions/bpd/citizenv2 && gen-api-models --api-spec ./bonus/specs/bpd/citizen_v2.json --out-dir ./generated/definitions/bpd/citizenv2 --no-strict --request-types --response-decoders",
     "generate:pagopa-bpd-winning-transactions-v2": "rimraf ./generated/definitions/bpd/winningTransactionsv2 && mkdir -p generated/definitions/bpd/winningTransactionsv2 && gen-api-models --api-spec ./bonus/specs/bpd/winning_transactions_v2.json --out-dir ./generated/definitions/bpd/winningTransactionsv2 --no-strict --request-types --response-decoders",
     "generate:all": "npm-run-all generate:content-definitions generate:pagopa-cobadge generate:pagopa-privative generate:pagopa-walletv2-definitions generate:pagopa-bpd-citizen-v2 generate:pagopa-bpd-winning-transactions-v2",
-    "run_checks": "npm-run-all check_idps_list_data check_contextual_help_data check_bonus_available_data check_backend_status check_abi check_cobadge check_privative"
+    "run_checks": "npm-run-all check_idps_list_data check_contextual_help_data check_bonus_available_data check_backend_status check_abi check_cobadge check_privative check_services_webview_data"
   },
   "devDependencies": {
     "@types/chalk": "^2.2.0",

--- a/src/checks/checkVisibleServicesWebView.ts
+++ b/src/checks/checkVisibleServicesWebView.ts
@@ -1,6 +1,6 @@
 /**
- * this script defines the types representing the json data contained in /services-webview
- * to ensure they are in the expected format by the client
+ * this script defines the types representing the json data contained in "/services-webview" folder
+ * to ensure they are in the expected and don't have semantic errors
  */
 
 import * as t from "io-ts";

--- a/src/checks/checkVisibleServicesWebView.ts
+++ b/src/checks/checkVisibleServicesWebView.ts
@@ -1,0 +1,77 @@
+/**
+ * this script defines the types representing the json data contained in /services-webview
+ * to ensure they are in the expected format by the client
+ */
+
+import * as t from "io-ts";
+import { OrganizationFiscalCode } from "italia-ts-commons/lib/strings";
+import { ScopeEnum } from "../../generated/definitions/content/Service";
+import { enumType } from "italia-ts-commons/lib/types";
+import fs from "fs";
+import { readableReport } from "italia-ts-commons/lib/reporters";
+
+const ServiceO = t.partial({
+  d: t.string,
+  sc: enumType<ScopeEnum>(ScopeEnum, "scope")
+});
+
+const ServiceR = t.interface({
+  i: t.string,
+  n: t.string,
+  q: t.number
+});
+
+const Organization = t.interface({
+  fc: OrganizationFiscalCode,
+  o: t.string,
+  s: t.readonlyArray(t.intersection([ServiceR, ServiceO]))
+});
+const Organizations = t.readonlyArray(Organization);
+const files: ReadonlyArray<string> = [
+  "/../../services-webview/visible-services-compact.json",
+  "/../../services-webview/visible-services-extended.json"
+];
+
+const error = (message: string) => {
+  console.error(message);
+  process.exit(1);
+};
+
+files.forEach(file => {
+  const fileName = file.split("/").reverse()[0];
+  const fileContent = fs.readFileSync(__dirname + file).toString();
+  const organizations = Organizations.decode(JSON.parse(fileContent));
+  // check if data represents valid Organizations
+  if (organizations.isLeft()) {
+    error(
+      `${fileName} is not compatible with Organizations type: ${readableReport(
+        organizations.value
+      )}`
+    );
+    return;
+  }
+
+  // check if there are organization/services ID repetitions
+  const orgsCf = new Set<string>();
+  const servicesId = new Set<string>();
+  organizations.value.forEach(org => {
+    // organizations
+    const prevSize = orgsCf.size;
+    if (orgsCf.add(org.fc).size === prevSize) {
+      error(
+        `"${fileName}" - organization fiscal code ${
+          org.fc
+        } is present multiple times`
+      );
+    }
+    // inner services
+    org.s.forEach(serv => {
+      const prevServiceIdSize = servicesId.size;
+      if (servicesId.add(serv.i).size === prevServiceIdSize) {
+        error(`"${fileName}" - service ID ${org.fc} is present multiple times`);
+      }
+    });
+  });
+});
+
+process.exit(0);


### PR DESCRIPTION
This PR add a check on `visible service webview data`

- [x] json files carry data in an expected format
- [x] there are no repetitions of `organization fiscal code` or `service id `