### PR TITLE
[IA-97] Add type definition and backend section for manage favourite language status bar

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -321,6 +321,7 @@ definitions:
       - satispay
       - services
       - wallets
+      - favourite_language
     properties:
       bancomat:
         $ref: "#/definitions/SectionStatus"

--- a/status/backend.json
+++ b/status/backend.json
@@ -175,7 +175,7 @@
       "level": "normal",
       "message": {
         "it-IT": "",
-        "en-EN": "."
+        "en-EN": ""
       }
     }
   }

--- a/status/backend.json
+++ b/status/backend.json
@@ -169,6 +169,14 @@
         "it-IT": "",
         "en-EN": "."
       }
+    },
+    "favourite_language": {
+      "is_visible": false,
+      "level": "normal",
+      "message": {
+        "it-IT": "",
+        "en-EN": "."
+      }
     }
   }
 }


### PR DESCRIPTION
This PR add the `favourite_language` section to the `Section` type definition and corresponding backend section for manage the favourite language status bar in the app.