### PR TITLE
[IA-149]Add favourite_language properties field

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -351,6 +351,8 @@ definitions:
         $ref: "#/definitions/SectionStatus"
       wallets:
         $ref: "#/definitions/SectionStatus"
+      favourite_language:
+        $ref: "#/definitions/SectionStatus"
   SectionStatus:
     type: object
     description: The status of a specific app section


### PR DESCRIPTION
This PR fix a bug introduced in #406.
The `favorite_language` field was inserted without the type definition in the `properties` field.