### PR TITLE
[ASZ-103] Add zendesk remote feature flag

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -396,6 +396,8 @@ definitions:
         type: boolean
       cgn_merchants_v2:
         type: boolean
+      zendesk:
+        $ref: "#/definitions/ZendeskConfig"
   BpdConfig:
     type: object
     description: A specific config for BPD bonus
@@ -409,3 +411,13 @@ definitions:
       program_active:
         description: "If true, the cashback program is active and all the related in app functionalities are enabled"
         type: boolean
+  ZendeskConfig:
+    type: object
+    description: A specific config for Zendesk
+    required:
+      - active
+    properties:
+      active:
+        description: "If true, Zendesk is active while Instabug is deactivated"
+        type: boolean
+

--- a/status/backend.json
+++ b/status/backend.json
@@ -12,6 +12,9 @@
     {
       "enroll_bpd_after_add_payment_method": false,
       "program_active": true
+    },
+    "zendesk": {
+      "active": false
     }
   },
   "sections": {


### PR DESCRIPTION
This PR add the type definition and the config (at the moment setted to off) for Zendesk.
The choice to use an object was made because it allows to extend it in the future.