### PR TITLE
set zendesk as assistanceTool

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -14,7 +14,7 @@
       "program_active": false
     },
     "assistanceTool": {
-      "tool": "instabug"
+      "tool": "zendesk"
     },
     "paypal": {
       "enabled": true


### PR DESCRIPTION
This PR set Zendesk as assistanceTool so that the users can send assistance request in Zendesk.