### PR TITLE
[IA-768] Add a remote Feature Flag for the Premium Messages opt-in/out feature

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -626,7 +626,15 @@ definitions:
         type: string
       en-EN:
         type: string
-
+  PremiumMessages:
+    type: object
+    description: "A configuration for the Premium Messages feature"
+    required:
+      - enabled
+    properties:
+      opt_in_enabled:
+        type: boolean
+        description: "If true, an opt-in/out screen for the Premium Messages feature will be showed to the user while onboarding and in the settings"
 
 
 

--- a/definitions.yml
+++ b/definitions.yml
@@ -633,7 +633,7 @@ definitions:
     type: object
     description: "A configuration for the Premium Messages feature"
     required:
-      - enabled
+      - opt_in_enabled
     properties:
       opt_in_enabled:
         type: boolean

--- a/definitions.yml
+++ b/definitions.yml
@@ -400,6 +400,7 @@ definitions:
       - cgn
       - uaDonations
       - fims
+      - premiumMessages
     properties:
       bpd:
         $ref: "#/definitions/BpdConfig"
@@ -421,6 +422,8 @@ definitions:
         $ref: "#/definitions/UaDonationsConfig"
       fims:
         $ref: "#/definitions/FimsConfig"
+      premiumMessages:
+        $ref: "#/definitions/PremiumMessagesConfig"
   BpdConfig:
     type: object
     description: A specific config for BPD bonus
@@ -626,7 +629,7 @@ definitions:
         type: string
       en-EN:
         type: string
-  PremiumMessages:
+  PremiumMessagesConfig:
     type: object
     description: "A configuration for the Premium Messages feature"
     required:

--- a/definitions.yml
+++ b/definitions.yml
@@ -633,9 +633,9 @@ definitions:
     type: object
     description: "A configuration for the Premium Messages feature"
     required:
-      - opt_in_enabled
+      - opt_in_out_enabled
     properties:
-      opt_in_enabled:
+      opt_in_out_enabled:
         type: boolean
         description: "If true, an opt-in/out screen for the Premium Messages feature will be showed to the user while onboarding and in the settings"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -39,7 +39,7 @@
       }
     },
     "premiumMessages": {
-      "opt_in_enable": false
+      "opt_in_enabled": false
     }
   },
   "sections": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -39,7 +39,7 @@
       }
     },
     "premiumMessages": {
-      "opt_in_enabled": false
+      "opt_in_out_enabled": false
     }
   },
   "sections": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -37,6 +37,9 @@
         },
         "url": "https://assets.cdn.io.italia.it/html/donate.html"
       }
+    },
+    "premiumMessages": {
+      "opt_in_enable": false
     }
   },
   "sections": {


### PR DESCRIPTION
This PR is going to add a `PremiumMessages` configuration object with a `opt_in_enabled` property used as a remote Feature Flag for the Premium Messages opt-in/out feature.