### PR TITLE
[IAFIMS-8] Supports domain specification for fims

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -468,10 +468,14 @@ definitions:
     description: "dedicated config for the FIMS (Federated Identity Management System) feature"
     required:
       - enabled
+      - domain
     properties:
       enabled:
         type: boolean
         description: "If true FIMS feature is available in those app that support it"
+      domain:
+        type: string
+        description: "This is the url that will be used to store the session cookie inside the app dedicated webview"
   AssistanceToolConfig:
     type: object
     description: "A specific config for the assistance tool"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.10",
+  "version": "1.0.11",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -25,7 +25,8 @@
       "merchants_v2": false
     },
     "fims": {
-      "enabled": false
+      "enabled": false,
+      "domain": ""
     },
     "uaDonations": {
       "enabled": true,


### PR DESCRIPTION
This PR supports the remote configuration for a defined domain to use as the cookie domain for FIMS session token