### PR TITLE
[IA-791] Add BancomatPay config

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -459,7 +459,11 @@ definitions:
     required:
       - onboarding
       - payment
+      - display
     properties:
+      display:
+        type: boolean
+        description: "If true BPay can be showed in the wallet section"
       onboarding:
         type: boolean
         description: "If true BPay can be added in the user's wallet"

--- a/definitions.yml
+++ b/definitions.yml
@@ -397,6 +397,7 @@ definitions:
       - cgn_merchants_v2
       - assistanceTool
       - paypal
+      - bancomatPay
       - cgn
       - uaDonations
       - fims
@@ -416,6 +417,8 @@ definitions:
         $ref: "#/definitions/AssistanceToolConfig"
       paypal:
         $ref: "#/definitions/PaypalConfig"
+      bancomatPay:
+        $ref: "#/definitions/BancomatPayConfig"
       cgn:
         $ref: "#/definitions/CgnConfig"
       uaDonations:
@@ -450,6 +453,19 @@ definitions:
       enabled:
         type: boolean
         description: "If true paypal is available in those app that support it"
+  BancomatPayConfig:
+    type: object
+    description: "dedicated config for the BancomatPay payment method"
+    required:
+      - onboarding
+      - payment
+    properties:
+      onboarding:
+        type: boolean
+        description: "If true BPay can be added in the user's wallet"
+      payment:
+        type: boolean
+        description: "If true BPay can be used to pay"
   CgnConfig:
     type: object
     description: "dedicated config for the CGN app flow"

--- a/status/backend.json
+++ b/status/backend.json
@@ -20,6 +20,10 @@
     "paypal": {
       "enabled": true
     },
+    "bancomatPay": {
+      "onboarding": true,
+      "payment": true
+    },
     "cgn": {
       "enabled": true,
       "merchants_v2": false

--- a/status/backend.json
+++ b/status/backend.json
@@ -21,8 +21,9 @@
       "enabled": true
     },
     "bancomatPay": {
+      "display": true,
       "onboarding": true,
-      "payment": true
+      "payment": false
     },
     "cgn": {
       "enabled": true,


### PR DESCRIPTION
This PR adds a dedicated config for BancomatPay
It includes 3 flags:

- `display` If true BPay can be showed in the wallet section
- `onboarding` If true BPay can be added in the user's wallet
- `payment` If true BPay can be used to pay