### PR TITLE
[IA-669] Copy updates to the FAQs of the Wallet section

### DIFF
--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -3,6 +3,160 @@
    "it": {
       "screens": [
         {
+        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+        "title": "Paga con la tua carta supermercato",
+        "content": "In questa pagina puoi aggiungere la tua carta supermercato come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
+        "faqs": [
+          {
+            "title": "Quali carte supermercato posso aggiungere?",
+            "body": "Puoi aggiungere soltanto le carte supermercato che permettono di pagare. Non sono valide le carte supermercato che non consentono di effettuare pagamenti, ma solo di accumulare punti o avere accesso a sconti."
+          }
+          {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
+        "title": "Paga con la tua carta PagoBANCOMAT",
+        "content": "In questa pagina puoi aggiungere una carta PagoBANCOMAT come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio. Prima di procedere all'aggiunta delle tue carte PagoBANCOMAT, ti invitiamo a leggere l'informativa.",
+        "faqs": [
+          {
+            "title": "Perché non trovo la mia banca?",
+            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Se premi su “Continua”, IO cercherà tutte le carte PagoBANCOMAT a te intestate sulla base del tuo codice fiscale, che viene recuperato dallo SPID o dalla CIE con cui hai effettuato l'accesso."
+          }
+        ]
+      },
+        {
+        "route_name": "WALLET_ADD_CARD",
+        "title": "Paga con una carta credito, debito o prepagata",
+        "content": "In questa pagina puoi aggiungere una carta di credito, debito o prepagata come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
+        "faqs": [
+          {
+            "title": "Dove trovo il codice di sicurezza?",
+            "body": "Il codice di sicurezza, chiamato anche CVV o CVS, è un codice a tre cifre che si trova sul retro della tua carta. Sulle carte American Express si chiama CID, è a quattro cifre e si trova sul fronte. Se non lo trovi, probabilmente la tua carta non è abilitata ai pagamenti online."
+          },
+          {
+            "title": "Non riesco ad aggiungere la mia carta. Come mai?",
+            "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n*La tua carta non è abilitata agli acquisti online;\n\n*La tua carta è stata messa “in pausa”;\n\n*Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
+          }
+        ]
+      },
+        {
+        "route_name": "WALLET_PRIVATIVE_DETAIL",
+        "title": "La tua carta supermercato",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          }
+        ]
+      },
+        {
+        "route_name": "WALLET_BANCOMAT_DETAIL",
+        "title": "La tua carta PagoBANCOMAT",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          },
+        {
+            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+          },
+          {
+            "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
+            "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n*Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n*Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
+          }
+        ]
+      },
+        {
+        "route_name": "WALLET_PAYPAL_DETAIL",
+        "title": "Il tuo account PayPal",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          }
+        ]
+      },
+        {
+        "route_name": "WALLET_CREDIT_CARD_DETAIL",
+        "title": "La tua carta",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          }
+        ]
+      },
+        {
+        "route_name": "WALLET_HOME",
+        "title": "Cosa puoi fare nel tuo Portafoglio",
+        "content": "Nel Portafoglio trovi i metodi di pagamento che hai aggiunto, i bonus e le iniziative a cui hai aderito e lo storico delle transazioni effettuate con pagoPA, la piattaforma dei pagamenti verso la Pubblica Amministrazione. In questa sezione, puoi anche pagare tutti gli avvisi di pagamento cartacei con il logo pagoPA.",
+        "faqs": [
+          {
+            "title": "Come posso pagare su IO?",
+            "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento)."
+          },
+          {
+            "title": "Come posso aggiungere un metodo di pagamento?",
+            "body": "Vai al Portafoglio, premi “Aggiungi” e “Metodo di Pagamento”. Poi, seleziona il metodo che vuoi aggiungere e inserisci i dati richiesti."
+          },
+          {
+            "title": "Quali bonus, sconti o altre iniziative posso richiedere?",
+            "body": "Vai al Portafoglio, premi “Aggiungi” e “Sconti, bonus e altre iniziative”. Comparirà una lista con tutti i bonus e le iniziative che puoi richiedere tramite l’app IO."
+          },
+          {
+            "title": "Non riesco ad aggiungere un metodo di pagamento. Cosa posso fare?",
+            "body": "Accedi alla pagina [stato aggiunta metodi di pagamento] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
+          },
+          {
+            "title": "Come posso eliminare un metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          },
+          {
+            "title": "Ho un problema con un pagamento. Cosa posso fare?",
+            "body": "Accedi alla pagina [stato dei tuoi pagamenti] (ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
+          },
+          {
+            "title": "Dove trovo i pagamenti che ho effettuato?",
+            "body": "Nel Portafoglio trovi una lista che contiene i pagamenti effettuati con successo tramite l’app IO. La lista include anche i pagamenti effettuati tramite il sito o l’app degli enti aderenti, se ti sei autenticato con SPID."
+          },
+          {
+            "title": "Posso pagare un avviso che non ho ricevuto tramite IO?",
+            "body": "Sì, se sull’avviso sono presenti il logo pagoPA e il codice QR o il Codice Avviso. Per farlo, vai nel Portafoglio, scansiona il QR o inserisci il Codice Avviso e completa il pagamento."
+          },
+          {
+            "title": "Che cos’è un codice QR?",
+            "body": "Il codice QR è un’immagine quadrata composta da elementi bianchi e neri. Se inquadrato dalla fotocamera di un telefono permette di accedere a contenuti digitali, come ad esempio un sito web, un pagamento o un articolo.\n\nIl codice QR che trovi sugli avvisi di pagamento è associato a un Codice Avviso. Se vai al tuo Portafoglio, premi su “Paga un avviso” e inquadri il codice con la fotocamera, puoi pagare l’avviso senza dover inserire manualmente informazioni come causale, cifra o codice fiscale."
+          },
+          {
+            "title": "Che cos’è pagoPA?",
+            "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA] (https://www.pagopa.gov.it/)."
+          },
+          {
+            "title": "Come posso saperne di più sui pagamenti digitali?",
+            "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata] (https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti] (https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico] (https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+          },
+        ]
+      },
+        {
         "route_name": "UADONATION_ROUTES_WEBVIEW",
         "title": "Donazioni Ucraina",
         "content": "In questa pagina, puoi fare una donazione alle organizzazioni umanitarie che assistono le vittime civili della crisi in Ucraina.",
@@ -55,14 +209,14 @@
             "body": "Per sostenere i costi di gestione e garantire la sicurezza del trasferimento di denaro, ogni gestore della transazione può applicare una commissione variabile. La commissione varia a seconda delle politiche commerciali e delle condizioni contrattuali sottoscritte col gestore che hai scelto. IO ti mostrerà sempre il costo della transazione indicato dal gestore della transazione, per permetterti di scegliere quello più conveniente."
           },
            {
-            "title": "Non riesco ad aggiungere PayPal come metodo di pagamento su IO.",
-            "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal su IO, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
+            "title": "Non riesco ad aggiungere PayPal come metodo di pagamento.",
+            "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
           }
         ]
       },
          {
         "route_name": "WALLET_ONBOARDING_PAYPAL_START",
-        "title": "Paga su IO con PayPal",
+        "title": "Paga con PayPal",
         "content": "In questa pagina potrai aggiungere PayPal come metodo di pagamento nell’app IO.\n\nPayPal ti permette di pagare senza inserire ogni volta i tuoi dati finanziari. Ti permette anche di collegare il tuo conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.",
         "faqs": [
           {
@@ -75,7 +229,7 @@
           },
           {
             "title": "Che vantaggi ho ad utilizzare PayPal per pagare tramite IO?",
-            "body": "PayPal ti permetterà di autorizzare le operazioni di pagamento su IO in modo semplice e veloce, senza che tu debba inserire i tuoi dati finanziari.\n\nPuoi collegare al tuo conto PayPal non solo la carta di credito, di debito o prepagata, ma anche il conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.\n\n[Scopri qui](https://www.paypal.com/it/smarthelp/article/come-faccio-a-collegare-il-mio-conto-bancario-al-mio-conto-paypal-faq686) come collegare il tuo conto bancario a PayPal."
+            "body": "PayPal ti permetterà di autorizzare le operazioni di pagamento in modo semplice e veloce, senza che tu debba inserire i tuoi dati finanziari.\n\nPuoi collegare al tuo conto PayPal non solo la carta di credito, di debito o prepagata, ma anche il conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.\n\n[Scopri qui](https://www.paypal.com/it/smarthelp/article/come-faccio-a-collegare-il-mio-conto-bancario-al-mio-conto-paypal-faq686) come collegare il tuo conto bancario a PayPal."
           },
           {
             "title": "Non ho un conto PayPal. Come posso crearne uno?",
@@ -560,51 +714,14 @@
             ]
          },
          {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_CHOOSE_BANK",
-            "title": "Informativa sul trattamento dei dati personali",
-            "content": "In questa schermata ti invitiamo a leggere l'informativa prima di procedere all'aggiunta delle tue carte PagoBANCOMAT.",
-            "faqs": [
-               {
-                  "title": "Cosa devo fare adesso?",
-                  "body": "IO è in grado di risalire a tutte le carte PagoBANCOMAT a te intestate sulla base del tuo codice fiscale, che viene preso dall'account SPID o CIE con cui hai effettuato l'accesso. **In questo caso premi semplicemente su Continua.**\nSe vuoi puoi anche cercare il nome della tua banca, ma non è necessario."
-               },
-               {
-                  "title": "Perché non trovo la mia banca?",
-                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una Banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni.\n\n**Premi su Continua e IO cercherà tutte le carte PagoBANCOMAT a te intestate** sulla base del tuo codice fiscale, che viene preso dall'account SPID o CIE con cui hai effettuato l'accesso."
-               }
-            ]
-         },
-         {
             "route_name": "WALLET_ONBOARDING_BANCOMAT_SEARCH_AVAILABLE_USER_BANCOMAT",
             "title": "Le tue carte PagoBANCOMAT",
             "content": "In questa schermata ti mostriamo la o le carte PagoBANCOMAT a te intestate. Puoi aggiungerle premendo 'Aggiungi', oppure saltare la carta in questione per uscire dal flusso o passare alla carta successiva nel caso ne siano state trovate più di una.",
             "faqs": [
                {
-                  "title": "Una volta abilitata la carta, posso iniziare subito a collezionare transazioni?",
-                  "body": "No, quando si aggiunge un nuovo metodo di pagamento, verranno collezionate le transazioni effettuate a partire dalle 00:01 del giorno successivo a quello dell'attivazione."
-               },
-               {
                   "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
                   "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
                },
-               {
-                  "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                  "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-               },
-               {
-                  "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                  "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-               },
-               {
-                  "title": "Posso salvare tra i metodi di pagamento per il Cashback una carta già registrata ai fini del programma da un altro partecipante?",
-                  "body": "No, lo stesso metodo di pagamento non può essere attivato contemporaneamente da due o più partecipanti al programma."
-               },
-               {
-                  "title": "Ho appena registrato un metodo di pagamento al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                  "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-               }
-            ]
-         },
          {
             "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
             "title": "Vuoi iscriverti al programma Cashback?",
@@ -663,33 +780,6 @@
                {
                   "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
                   "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_BANCOMAT_DETAIL",
-            "title": "La tua carta PagoBANCOMAT",
-            "content": "Questa è la schermata di dettaglio della tua carta PagoBANCOMAT. Sulla carta sono rappresentati il logo della banca che ha emesso la carta e la data di scadenza.",
-            "faqs": [
-               {
-                  "title": "Cosa posso fare da qui?",
-                  "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento, come ad esempio il Cashback.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
-               },
-               {
-                  "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-               },
-               {
-                  "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
-                  "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online, ma esistono altri modi per pagare su IO con la tua carta: \n- aggiungi al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n- aggiungi il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
-               },
-               {
-                  "title": "Cosa succede se disattivo o elimino dall’app IO un metodo di pagamento su cui è attivo il Cashback?",
-                  "body": "Continuerai a vedere le transazioni valide effettuate con quel metodo fino a quel giorno, ma non potrai accumularne di nuove dopo la mezzanotte del giorno in cui l’hai cancellato."
-               },
-               {
-                  "title": "Ho disattivato il Cashback su una mia carta ma vedo che, con quella carta, continuo ancora a collezionare acquisti validi ai fini del programma, come mai?",
-                  "body": "Se scegli di cancellare o sospendere temporaneamente un metodo di pagamento precedentemente registrato, la disattivazione o la sospensione della raccolta delle transazioni su quello strumento è effettiva a partire dalla mezzanotte del giorno successivo."
                }
             ]
          },
@@ -753,7 +843,7 @@
             "faqs": [
                {
                   "title": "Cosa posso fare da qui?",
-                  "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento, come ad esempio il Cashback.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
+                  "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
                },
                {
                   "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
@@ -767,41 +857,6 @@
                   "title": "Perché il numero della carta è diverso?",
                   "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
                },
-               {
-                  "title": "Cosa succede se disattivo o elimino dall’app IO un metodo di pagamento su cui è attivo il Cashback?",
-                  "body": "Continuerai a vedere le transazioni valide effettuate con quel metodo fino a quel giorno, ma non potrai accumularne di nuove dopo la mezzanotte del giorno in cui l’hai cancellato."
-               },
-               {
-                  "title": "Ho disattivato il Cashback su una mia carta ma vedo che, con quella carta, continuo ancora a collezionare acquisti validi ai fini del programma, come mai?",
-                  "body": "Se scegli di cancellare o sospendere temporaneamente un metodo di pagamento precedentemente registrato, la disattivazione o la sospensione della raccolta delle transazioni su quello strumento è effettiva a partire dalla mezzanotte del giorno successivo."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_PAYMENT_METHOD_DETAIL",
-            "title": "La tua carta di debito (o credito)",
-            "content": "Questa è la schermata di dettaglio della tua carta di debito (o credito). Sulla carta sono rappresentati il logo del circuito, l'intestatario, la data di scadenza e le ultime 4 cifre della carta.",
-            "faqs": [
-               {
-                  "title": "Cosa posso fare da qui?",
-                  "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento, come ad esempio il Cashback.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
-               },
-               {
-                  "title": "Cosa sono i pagamenti in app?",
-                  "body": "Se lo desideri, questo metodo ti permette di pagare su IO tutti gli avvisi pagoPA, anche quelli cartacei."
-               },
-               {
-                  "title": "Cosa significa 'Usa come preferito'?",
-                  "body": "Quando paghi in app, IO può mostrare in automatico questo metodo di pagamento se lo imposti come preferito. È necessario avere almeno un metodo preferito nel tuo Portafoglio."
-               },
-               {
-                  "title": "Cosa succede se disattivo o elimino dall’app IO un metodo di pagamento su cui è attivo il Cashback?",
-                  "body": "Continuerai a vedere le transazioni valide effettuate con quel metodo fino a quel giorno, ma non potrai accumularne di nuove dopo la mezzanotte del giorno in cui l’hai cancellato."
-               },
-               {
-                  "title": "Ho disattivato il Cashback su una mia carta ma vedo che, con quella carta, continuo ancora a collezionare acquisti validi ai fini del programma, come mai?",
-                  "body": "Se scegli di cancellare o sospendere temporaneamente un metodo di pagamento precedentemente registrato, la disattivazione o la sospensione della raccolta delle transazioni su quello strumento è effettiva a partire dalla mezzanotte del giorno successivo."
-               }
             ]
          },
          {
@@ -1003,10 +1058,240 @@
             "recover_password": "https://login.id.tim.it/mps/fp.php"
          }
       }
-   },
+   }],
    "en": {
       "screens": [
         {
+        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+        "title": "Pay with your supermarket card",
+        "content": "Here you can add your supermarket card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
+        "faqs": [
+          {
+            "title": "Which supermarket cards can I add?",
+            "body": "You can add only supermarket cards that allow you to pay. Supermarket cards that allow you to collect points or get access to discounts only are not valid."
+          }
+          {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
+        "title": "Pay with your PagoBANCOMAT card",
+        "content": "Here you can add your PagoBANCOMAT card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet. Before proceeding with the addition of your PagoBANCOMAT cards, please read the privacy policy.",
+        "faqs": [
+          {
+            "title": "Why can't I find my bank?",
+            "body": "Probably your PagoBANCOMAT card has been issued by a different bank. If you press “Add”, IO will search for all the PagoBANCOMAT cards in your name based on your tax code, which is deducted from the SPID or CIE you used to log in."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ADD_CARD",
+        "title": "Pay with a credit, debit, or prepaid card",
+        "content": "Here you can add your credit, debit, or prepaid card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
+        "faqs": [
+            {
+            "title": "Where do I find the security code?",
+            "body": "The security code, also called CVV or CVS, is a three-digit code on the back of your card. In American Express cards it's called CID, it has four digits and is located on the front. If you can't find the security code, your card probably isn't enabled for online payments."
+          },
+          {
+            "title": "I’m having trouble adding my card. What can I do?",
+            "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n*Your card is not enabled for online purchases; \n\n*Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page] (https://io.italia.it/metodi-pagamento/)."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_PRIVATIVE_DETAIL",
+        "title": "Your supermarket card",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_BANCOMAT_DETAIL",
+        "title": "Your PagoBANCOMAT card",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+          },
+        {
+            "title": "Why is the bank's name and logo different from the name and logo on my card?",
+            "body": "Your PagoBANCOMAT card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
+          },
+          {
+            "title": "Why does it say my card is not compatible with in-app payments?",
+            "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n*Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n*Add the second circuit, if your card has the security code and is already enabled for online payments."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_PAYPAL_DETAIL",
+        "title": "Your PayPal account",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_CREDIT_CARD_DETAIL",
+        "title": "Your card",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_HOME",
+        "title": "What can you do in your Wallet",
+        "content": "In the Wallet you can find the payment methods you have added, the bonuses and initiatives you have joined and the history of transactions made with pagoPA, the platform for payments to the Public Administration. Here, you can also pay all the payment notices with the pagoPA logo.",
+        "faqs": [
+          {
+            "title": "How can I pay on IO?",
+            "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page] (https://io.italia.it/metodi-pagamento)."
+          },
+          {
+            "title": "How do I add a payment method?",
+            "body": "Go to the Wallet, press “Add”, and then “Payment method”. Select the method you want to add and enter the required information."
+          },
+          {
+            "title": "What bonuses, discounts or other initiatives can I apply for?",
+            "body": "Go to Wallet, select “Add” and “Discounts, bonuses and other initiatives”. You will see a list with all the bonuses and initiatives you can apply for through IO."
+          },
+          {
+            "title": "I have trouble adding a payment method. What can I do?",
+            "body": "Go to the [payment method addition status page] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
+          },
+          {
+            "title": "How can I delete a payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
+          },
+          {
+            "title": "I have trouble with a payment. What can I do?",
+            "body": "Go to [your payment status page] (ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
+          },
+          {
+            "title": "Where do I find the payments I have made?",
+            "body": "In the Wallet you will find a list of successful payments you have made through IO. The list also includes payments made through the partner institutions' website or app, if you logged in with SPID."
+          },
+          {
+            "title": "Can I pay a notice that I did not receive through IO?",
+            "body": "Yes, if the notice features the pagoPA logo and QR code or Notice Code. To do so, go to the Wallet, scan the QR or enter the Notice Code and complete the payment."
+          },
+          {
+            "title": "What is a QR code?",
+            "body": "The QR code is a square image made of white and black elements. When you scan it with a device's camera, it provides direct access to digital content, such as a website, a payment, or an item.\The QR code you find on payment notices is linked to a Notice Code. If you go to your Wallet, press "Pay Notice" and scan the code with your camera, you can pay the notice without having to manually enter information such as a description, amount or tax code."
+          },
+          {
+            "title": "What is pagoPA?",
+            "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website] (https://www.pagopa.gov.it/)."
+          },
+          {
+            "title": "How can I learn more about digital payments?",
+            "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section] (https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+          },
+        ]
+      },
+      {
+            "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
+            "title": "Add the second network of your PagoBANCOMAT card",
+            "content": "In order to properly add the international network associated to your PagoBANCOMAT card, we need to know if you have ever used this card online, so that we can redirect you to the relevant page.",
+            "faqs": [
+               {
+                  "title": "How do I understand if my card is enabled for online payments?",
+                  "body": "Your card must have a security code: it is a 3 digit code and is printed on the back. If you can't find it, it means that you can only use your card in stores.\n\n Also make sure that you have enabled the 3D Secure service (Mastercard Identity Check for Mastercard cards and Verified By Visa/Visa Secure for Visa cards). For more information, go to your home banking or contact your bank."
+               },
+               {
+                  "title": "My card has the security code, but I still can't add it to the Wallet.",
+                  "body": "After entering your card details, your bank runs a check, usually via SMS or with a notification through its app. Follow the instructions given by your bank and, in case of trouble, contact their customer service.\n\nIf you do not receive any message (or the transaction is denied) it means that your card is not enabled for online payments. Contact your bank and ask how to activate 3D Secure (Mastercard Identity Check for Mastercard cards and Verified By Visa/Visa Secure for Visa cards)."
+               },
+               {
+                  "title": "I have already added the second network. What should I do?",
+                  "body": "If you have already added the international network to the Wallet as a “debit/credit card”, there is no need to add the card again with this feature."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ONBOARDING_COBADGE_START",
+            "title": "Add the second network of your PagoBANCOMAT card",
+            "content": "This feature allows you to search for all the cards with international network (Maestro, Mastercard, Visa and V-Pay) in your name.",
+            "faqs": [
+              {
+                  "title": "Can I add cards with an international network?",
+                  "body": "Yes, you can add debit or credit cards with an international network (Maestro, Mastercard, VISA and V-Pay), even if they are not enabled for online payments. The cards must be in your name and issued by the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
+               },
+               {
+                  "title": "Why can't I find any cards?",
+                  "body": "The service searches only for international network cards in your name. Make sure that the card is actually in your name and is issued by one of the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
+            "title": "Add the second network of your PagoBANCOMAT card",
+            "content": "Here you can see all the cards in your name with an international network (Maestro, Mastercard, Visa and V-Pay), issued by the banks participating in the service. If you don't want to add one of the cards listed, press “Skip" and go to the next one.",
+            "faqs": [
+               {
+                  "title": "Why is the expiration date different?",
+                  "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
+               },
+               {
+                  "title": "Why is the card number different?",
+                  "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
+               },
+               {
+                  "title": "I have already added the second network, what should I do?",
+                  "body": "If you have already added the international network to the Wallet as a “debit/credit card”, there is no need to add the card again with this feature."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_COBADGE_DETAIL",
+            "title": "Your card with international network",
+            "content": "Here you can see the details of your international network card. You can see the logo of the bank that issued the card, the expiration date and the logo and number of the international network.",
+            "faqs": [
+               {
+                  "title": "What can I do here?",
+                  "body": "You can enable or disable some features for this payment method.\n\n You can also delete this payment method from your Wallet."
+               },
+               {
+                  "title": "Why is the bank's name and logo different from the name and logo on my card?",
+                  "body": "Your card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
+               },
+              {
+                  "title": "Why is the expiration date different?",
+                  "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
+               },
+               {
+                  "title": "Why is the card number different?",
+                  "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
+               },
+            ]
+          },
+          {
         "route_name": "UADONATION_ROUTES_WEBVIEW",
         "title": "Donations Ukraine",
         "content": "In this page, you can make a donation to charities assisting the civilian victims of the crisis in Ukraine.",
@@ -1114,4 +1399,3 @@
          }
       }
    }
-}

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -3,7 +3,7 @@
   "it": {
     "screens": [
       {
-        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSE_ISSUER",
         "title": "Paga con la tua carta supermercato",
         "content": "In questa pagina puoi aggiungere la tua carta supermercato come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
         "faqs": [
@@ -723,265 +723,265 @@
           {
             "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
             "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
-        "title": "Vuoi iscriverti al programma Cashback?",
-        "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
-        "faqs": [
-          {
-            "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-            "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
           },
           {
-            "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
-            "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
-        "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
-        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-        "faqs": [
-          {
-            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+            "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
+            "title": "Vuoi iscriverti al programma Cashback?",
+            "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
+            "faqs": [
+              {
+                "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
+                "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
+              },
+              {
+                "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
+                "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
+              }
+            ]
           },
           {
-            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+            "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
+            "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
+            "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+            "faqs": [
+              {
+                "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+                "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+              },
+              {
+                "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+                "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+              },
+              {
+                "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+                "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+              },
+              {
+                "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+                "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+              }
+            ]
           },
           {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+            "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
+            "title": "Attiva il Cashback sulle tue carte",
+            "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+            "faqs": [
+              {
+                "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+                "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+              },
+              {
+                "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+                "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+              },
+              {
+                "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+                "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+              },
+              {
+                "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+                "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+              }
+            ]
           },
           {
-            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
-        "title": "Attiva il Cashback sulle tue carte",
-        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-        "faqs": [
-          {
-            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+            "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
+            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+            "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
+            "faqs": [
+              {
+                "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
+                "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
+              },
+              {
+                "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
+                "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
+              },
+              {
+                "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+                "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+              }
+            ]
           },
           {
-            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+            "route_name": "WALLET_ONBOARDING_COBADGE_START",
+            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+            "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
+            "faqs": [
+              {
+                "title": "Posso aggiungere anche carte con circuito internazionale?",
+                "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
+              },
+              {
+                "title": "Perché non trovo alcuna carta?",
+                "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
+              }
+            ]
           },
           {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+            "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
+            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+            "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
+            "faqs": [
+              {
+                "title": "Perché la data di scadenza è diversa?",
+                "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+              },
+              {
+                "title": "Perché il numero della carta è diverso?",
+                "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+              },
+              {
+                "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+                "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+              }
+            ]
           },
           {
-            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
-        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-        "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
-        "faqs": [
-          {
-            "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
-            "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
+            "route_name": "WALLET_COBADGE_DETAIL",
+            "title": "La tua carta con circuito internazionale",
+            "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
+            "faqs": [
+              {
+                "title": "Cosa posso fare da qui?",
+                "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
+              },
+              {
+                "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+                "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+              },
+              {
+                "title": "Perché la data di scadenza è diversa?",
+                "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+              },
+              {
+                "title": "Perché il numero della carta è diverso?",
+                "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+              }
+            ]
           },
           {
-            "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
-            "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
+            "route_name": "AUTHENTICATION_LANDING",
+            "title": "Come accedere all'app IO",
+            "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
+            "faqs": [
+              {
+                "title": "Cos'è SPID?",
+                "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
+              },
+              {
+                "title": "Come puoi ottenere SPID?",
+                "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
+              },
+              {
+                "title": "Hai perso le tue credenziali SPID?",
+                "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
+              },
+              {
+                "title": "Cos'è la CIE?",
+                "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
+              },
+              {
+                "title": "Come puoi ottenere la CIE?",
+                "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
+              },
+              {
+                "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+                "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+              },
+              {
+                "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+                "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Posso ricevere su IO i certificati dei miei familiari?",
+                "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
+                "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
+              },
+              {
+                "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+                "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+                "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
+                "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
+              },
+              {
+                "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+                "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Usi Android e non riesci ad aggiornare IO?",
+                "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+              }
+            ]
           },
           {
-            "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-            "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_COBADGE_START",
-        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-        "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
-        "faqs": [
-          {
-            "title": "Posso aggiungere anche carte con circuito internazionale?",
-            "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
-          },
-          {
-            "title": "Perché non trovo alcuna carta?",
-            "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
-        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-        "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
-        "faqs": [
-          {
-            "title": "Perché la data di scadenza è diversa?",
-            "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-          },
-          {
-            "title": "Perché il numero della carta è diverso?",
-            "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-          },
-          {
-            "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-            "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_COBADGE_DETAIL",
-        "title": "La tua carta con circuito internazionale",
-        "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
-        "faqs": [
-          {
-            "title": "Cosa posso fare da qui?",
-            "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
-          },
-          {
-            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-            "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-          },
-          {
-            "title": "Perché la data di scadenza è diversa?",
-            "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-          },
-          {
-            "title": "Perché il numero della carta è diverso?",
-            "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-          }
-        ]
-      },
-      {
-        "route_name": "AUTHENTICATION_LANDING",
-        "title": "Come accedere all'app IO",
-        "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
-        "faqs": [
-          {
-            "title": "Cos'è SPID?",
-            "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
-          },
-          {
-            "title": "Come puoi ottenere SPID?",
-            "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
-          },
-          {
-            "title": "Hai perso le tue credenziali SPID?",
-            "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
-          },
-          {
-            "title": "Cos'è la CIE?",
-            "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
-          },
-          {
-            "title": "Come puoi ottenere la CIE?",
-            "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
-          },
-          {
-            "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-            "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-          },
-          {
-            "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-            "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Posso ricevere su IO i certificati dei miei familiari?",
-            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
-            "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
-          },
-          {
-            "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-            "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
-            "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
-          },
-          {
-            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Usi Android e non riesci ad aggiornare IO?",
-            "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-          }
-        ]
-      },
-      {
-        "route_name": "MESSAGES_HOME",
-        "title": "Cosa puoi fare nei tuoi Messaggi",
-        "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
-        "faqs": [
-          {
-            "title": "Che tipo di messaggi posso ricevere?",
-            "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
-          },
-          {
-            "title": "Cosa succede se archivio i messaggi?",
-            "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
-          },
-          {
-            "title": "I messaggi possono essere cancellati?",
-            "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
-          },
-          {
-            "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-            "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-          },
-          {
-            "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-            "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Posso ricevere su IO i certificati dei miei familiari?",
-            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
-            "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-          },
-          {
-            "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
-            "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-          },
-          {
-            "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-            "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
-            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-          },
-          {
-            "title": "Usi Android e non riesci ad aggiornare IO?",
-            "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+            "route_name": "MESSAGES_HOME",
+            "title": "Cosa puoi fare nei tuoi Messaggi",
+            "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
+            "faqs": [
+              {
+                "title": "Che tipo di messaggi posso ricevere?",
+                "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
+              },
+              {
+                "title": "Cosa succede se archivio i messaggi?",
+                "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
+              },
+              {
+                "title": "I messaggi possono essere cancellati?",
+                "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
+              },
+              {
+                "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+                "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+              },
+              {
+                "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+                "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Posso ricevere su IO i certificati dei miei familiari?",
+                "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
+                "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+              },
+              {
+                "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
+                "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+              },
+              {
+                "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+                "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
+                "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+                "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+                "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+              },
+              {
+                "title": "Usi Android e non riesci ad aggiornare IO?",
+                "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+              }
+            ]
           }
         ]
       }

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -1061,7 +1061,83 @@
                }
             }
          }
-      ]
+      ],
+      "idps": {
+         "arubaid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
+            "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+            "phone": "003905750504",
+            "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+            "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+            "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+            "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+         },
+         "infocertid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
+            "helpdesk_form": "https://contatta.infocert.it/ticket/",
+            "phone": "00390654641489",
+            "web_site": "https://identitadigitale.infocert.it/",
+            "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+            "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+         },
+         "intesaid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
+            "email": "hdintesa@advalia.com",
+            "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+            "phone": "800805093",
+            "phone_international": "00390287119396",
+            "web_site": "https://www.intesa.it/intesaid",
+            "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+         },
+         "lepidaid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
+            "email": "helpdesk@lepida.it",
+            "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+            "phone": "800445500",
+            "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+            "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+            "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+         },
+         "namirialid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
+            "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+            "phone": "003907163494",
+            "web_site": "https://www.namirialtsp.com/spid/",
+            "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+            "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+         },
+         "posteid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+            "helpdesk_form": "https://www.poste.it/scrivici.html",
+            "phone": "800007777",
+            "web_site": "https://posteid.poste.it",
+            "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+            "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+         },
+         "sielteid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
+            "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+            "phone": "00390957171301",
+            "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+            "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+         },
+         "spiditalia": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+            "phone": "+390355787979",
+            "web_site": "https://www.register.it/spid/ ",
+            "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+            "recover_password": "https://spid.register.it/selfcare/recovery/password"
+         },
+         "timid": {
+            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
+            "email": "supportotimid@telecomitalia.it",
+            "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+            "phone": "800405800",
+            "web_site": "https://spid.tim.it/tim-id-portal",
+            "recover_username": "https://login.id.tim.it/mps/fu.php",
+            "recover_password": "https://login.id.tim.it/mps/fp.php"
+         }
+      }
    },
    "en": {
       "screens": [

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -985,82 +985,82 @@
           }
         ]
       }
-    ]
-  },
-  "idps": {
-    "arubaid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
-      "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-      "phone": "003905750504",
-      "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-      "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-      "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-      "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-    },
-    "infocertid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
-      "helpdesk_form": "https://contatta.infocert.it/ticket/",
-      "phone": "00390654641489",
-      "web_site": "https://identitadigitale.infocert.it/",
-      "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-      "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-    },
-    "intesaid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
-      "email": "hdintesa@advalia.com",
-      "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-      "phone": "800805093",
-      "phone_international": "00390287119396",
-      "web_site": "https://www.intesa.it/intesaid",
-      "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-    },
-    "lepidaid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
-      "email": "helpdesk@lepida.it",
-      "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-      "phone": "800445500",
-      "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-      "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-      "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-    },
-    "namirialid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
-      "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-      "phone": "003907163494",
-      "web_site": "https://www.namirialtsp.com/spid/",
-      "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-      "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-    },
-    "posteid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-      "helpdesk_form": "https://www.poste.it/scrivici.html",
-      "phone": "800007777",
-      "web_site": "https://posteid.poste.it",
-      "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-      "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-    },
-    "sielteid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
-      "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-      "phone": "00390957171301",
-      "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-      "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-    },
-    "spiditalia": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-      "phone": "+390355787979",
-      "web_site": "https://www.register.it/spid/ ",
-      "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-      "recover_password": "https://spid.register.it/selfcare/recovery/password"
-    },
-    "timid": {
-      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
-      "email": "supportotimid@telecomitalia.it",
-      "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-      "phone": "800405800",
-      "web_site": "https://spid.tim.it/tim-id-portal",
-      "recover_username": "https://login.id.tim.it/mps/fu.php",
-      "recover_password": "https://login.id.tim.it/mps/fp.php"
+    ],
+    "idps": {
+      "arubaid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
+        "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+        "phone": "003905750504",
+        "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+        "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+        "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+        "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+      },
+      "infocertid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
+        "helpdesk_form": "https://contatta.infocert.it/ticket/",
+        "phone": "00390654641489",
+        "web_site": "https://identitadigitale.infocert.it/",
+        "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+        "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+      },
+      "intesaid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
+        "email": "hdintesa@advalia.com",
+        "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+        "phone": "800805093",
+        "phone_international": "00390287119396",
+        "web_site": "https://www.intesa.it/intesaid",
+        "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+      },
+      "lepidaid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
+        "email": "helpdesk@lepida.it",
+        "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+        "phone": "800445500",
+        "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+        "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+        "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+      },
+      "namirialid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
+        "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+        "phone": "003907163494",
+        "web_site": "https://www.namirialtsp.com/spid/",
+        "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+        "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+      },
+      "posteid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+        "helpdesk_form": "https://www.poste.it/scrivici.html",
+        "phone": "800007777",
+        "web_site": "https://posteid.poste.it",
+        "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+        "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+      },
+      "sielteid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
+        "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+        "phone": "00390957171301",
+        "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+        "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+      },
+      "spiditalia": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+        "phone": "+390355787979",
+        "web_site": "https://www.register.it/spid/ ",
+        "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+        "recover_password": "https://spid.register.it/selfcare/recovery/password"
+      },
+      "timid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
+        "email": "supportotimid@telecomitalia.it",
+        "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+        "phone": "800405800",
+        "web_site": "https://spid.tim.it/tim-id-portal",
+        "recover_username": "https://login.id.tim.it/mps/fu.php",
+        "recover_password": "https://login.id.tim.it/mps/fp.php"
+      }
     }
   },
   "en": {

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -1066,7 +1066,7 @@
   "en": {
     "screens": [
       {
-        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSE_ISSUER",
         "title": "Pay with your supermarket card",
         "content": "Here you can add your supermarket card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
         "faqs": [

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -723,344 +723,344 @@
           {
             "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
             "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
+        "title": "Vuoi iscriverti al programma Cashback?",
+        "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
+        "faqs": [
+          {
+            "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
+            "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
           },
           {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
-            "title": "Vuoi iscriverti al programma Cashback?",
-            "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
-            "faqs": [
-              {
-                "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-                "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
-              },
-              {
-                "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
-                "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
-              }
-            ]
+            "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
+            "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
+        "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
+        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+        "faqs": [
+          {
+            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
           },
           {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
-            "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
-            "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-            "faqs": [
-              {
-                "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-              },
-              {
-                "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-              },
-              {
-                "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-              },
-              {
-                "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-              }
-            ]
+            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
           },
           {
-            "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
-            "title": "Attiva il Cashback sulle tue carte",
-            "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-            "faqs": [
-              {
-                "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-              },
-              {
-                "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-              },
-              {
-                "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-              },
-              {
-                "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-              }
-            ]
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
           },
           {
-            "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
-            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-            "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
-            "faqs": [
-              {
-                "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
-                "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
-              },
-              {
-                "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
-                "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
-              },
-              {
-                "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-                "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-              }
-            ]
+            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
+        "title": "Attiva il Cashback sulle tue carte",
+        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+        "faqs": [
+          {
+            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
           },
           {
-            "route_name": "WALLET_ONBOARDING_COBADGE_START",
-            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-            "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
-            "faqs": [
-              {
-                "title": "Posso aggiungere anche carte con circuito internazionale?",
-                "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
-              },
-              {
-                "title": "Perché non trovo alcuna carta?",
-                "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
-              }
-            ]
+            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
           },
           {
-            "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
-            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-            "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
-            "faqs": [
-              {
-                "title": "Perché la data di scadenza è diversa?",
-                "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-              },
-              {
-                "title": "Perché il numero della carta è diverso?",
-                "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-              },
-              {
-                "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-                "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-              }
-            ]
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
           },
           {
-            "route_name": "WALLET_COBADGE_DETAIL",
-            "title": "La tua carta con circuito internazionale",
-            "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
-            "faqs": [
-              {
-                "title": "Cosa posso fare da qui?",
-                "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
-              },
-              {
-                "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-                "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-              },
-              {
-                "title": "Perché la data di scadenza è diversa?",
-                "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-              },
-              {
-                "title": "Perché il numero della carta è diverso?",
-                "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-              }
-            ]
+            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
+        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+        "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
+        "faqs": [
+          {
+            "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
+            "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
           },
           {
-            "route_name": "AUTHENTICATION_LANDING",
-            "title": "Come accedere all'app IO",
-            "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
-            "faqs": [
-              {
-                "title": "Cos'è SPID?",
-                "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
-              },
-              {
-                "title": "Come puoi ottenere SPID?",
-                "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
-              },
-              {
-                "title": "Hai perso le tue credenziali SPID?",
-                "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
-              },
-              {
-                "title": "Cos'è la CIE?",
-                "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
-              },
-              {
-                "title": "Come puoi ottenere la CIE?",
-                "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
-              },
-              {
-                "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-                "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-              },
-              {
-                "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-                "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
-                "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
-              },
-              {
-                "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-                "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-                "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
-                "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
-              },
-              {
-                "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Usi Android e non riesci ad aggiornare IO?",
-                "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-              }
-            ]
+            "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
+            "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
           },
           {
-            "route_name": "MESSAGES_HOME",
-            "title": "Cosa puoi fare nei tuoi Messaggi",
-            "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
-            "faqs": [
-              {
-                "title": "Che tipo di messaggi posso ricevere?",
-                "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
-              },
-              {
-                "title": "Cosa succede se archivio i messaggi?",
-                "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
-              },
-              {
-                "title": "I messaggi possono essere cancellati?",
-                "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
-              },
-              {
-                "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-                "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-              },
-              {
-                "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-                "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
-                "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-              },
-              {
-                "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
-                "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-              },
-              {
-                "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-                "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
-                "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-                "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-              },
-              {
-                "title": "Usi Android e non riesci ad aggiornare IO?",
-                "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-              }
-            ]
+            "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+            "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_START",
+        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+        "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
+        "faqs": [
+          {
+            "title": "Posso aggiungere anche carte con circuito internazionale?",
+            "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
+          },
+          {
+            "title": "Perché non trovo alcuna carta?",
+            "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
+        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+        "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
+        "faqs": [
+          {
+            "title": "Perché la data di scadenza è diversa?",
+            "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+          },
+          {
+            "title": "Perché il numero della carta è diverso?",
+            "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+          },
+          {
+            "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+            "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_COBADGE_DETAIL",
+        "title": "La tua carta con circuito internazionale",
+        "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
+        "faqs": [
+          {
+            "title": "Cosa posso fare da qui?",
+            "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
+          },
+          {
+            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+            "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+          },
+          {
+            "title": "Perché la data di scadenza è diversa?",
+            "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+          },
+          {
+            "title": "Perché il numero della carta è diverso?",
+            "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+          }
+        ]
+      },
+      {
+        "route_name": "AUTHENTICATION_LANDING",
+        "title": "Come accedere all'app IO",
+        "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
+        "faqs": [
+          {
+            "title": "Cos'è SPID?",
+            "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
+          },
+          {
+            "title": "Come puoi ottenere SPID?",
+            "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
+          },
+          {
+            "title": "Hai perso le tue credenziali SPID?",
+            "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
+          },
+          {
+            "title": "Cos'è la CIE?",
+            "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
+          },
+          {
+            "title": "Come puoi ottenere la CIE?",
+            "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
+          },
+          {
+            "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+            "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+          },
+          {
+            "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+            "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere su IO i certificati dei miei familiari?",
+            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
+            "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
+          },
+          {
+            "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+            "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
+            "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
+          },
+          {
+            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Usi Android e non riesci ad aggiornare IO?",
+            "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+          }
+        ]
+      },
+      {
+        "route_name": "MESSAGES_HOME",
+        "title": "Cosa puoi fare nei tuoi Messaggi",
+        "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
+        "faqs": [
+          {
+            "title": "Che tipo di messaggi posso ricevere?",
+            "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
+          },
+          {
+            "title": "Cosa succede se archivio i messaggi?",
+            "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
+          },
+          {
+            "title": "I messaggi possono essere cancellati?",
+            "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
+          },
+          {
+            "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+            "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+          },
+          {
+            "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+            "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere su IO i certificati dei miei familiari?",
+            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
+            "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+          },
+          {
+            "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
+            "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+          },
+          {
+            "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+            "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
+            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Usi Android e non riesci ad aggiornare IO?",
+            "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
           }
         ]
       }
-    ],
-    "idps": {
-      "arubaid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
-        "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-        "phone": "003905750504",
-        "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-        "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-        "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-        "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-      },
-      "infocertid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
-        "helpdesk_form": "https://contatta.infocert.it/ticket/",
-        "phone": "00390654641489",
-        "web_site": "https://identitadigitale.infocert.it/",
-        "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-        "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-      },
-      "intesaid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
-        "email": "hdintesa@advalia.com",
-        "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-        "phone": "800805093",
-        "phone_international": "00390287119396",
-        "web_site": "https://www.intesa.it/intesaid",
-        "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-      },
-      "lepidaid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
-        "email": "helpdesk@lepida.it",
-        "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-        "phone": "800445500",
-        "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-        "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-        "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-      },
-      "namirialid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
-        "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-        "phone": "003907163494",
-        "web_site": "https://www.namirialtsp.com/spid/",
-        "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-        "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-      },
-      "posteid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-        "helpdesk_form": "https://www.poste.it/scrivici.html",
-        "phone": "800007777",
-        "web_site": "https://posteid.poste.it",
-        "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-        "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-      },
-      "sielteid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
-        "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-        "phone": "00390957171301",
-        "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-        "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-      },
-      "spiditalia": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-        "phone": "+390355787979",
-        "web_site": "https://www.register.it/spid/ ",
-        "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-        "recover_password": "https://spid.register.it/selfcare/recovery/password"
-      },
-      "timid": {
-        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
-        "email": "supportotimid@telecomitalia.it",
-        "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-        "phone": "800405800",
-        "web_site": "https://spid.tim.it/tim-id-portal",
-        "recover_username": "https://login.id.tim.it/mps/fu.php",
-        "recover_password": "https://login.id.tim.it/mps/fp.php"
-      }
+    ]
+  },
+  "idps": {
+    "arubaid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
+      "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+      "phone": "003905750504",
+      "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+      "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+      "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+      "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+    },
+    "infocertid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
+      "helpdesk_form": "https://contatta.infocert.it/ticket/",
+      "phone": "00390654641489",
+      "web_site": "https://identitadigitale.infocert.it/",
+      "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+      "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+    },
+    "intesaid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
+      "email": "hdintesa@advalia.com",
+      "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+      "phone": "800805093",
+      "phone_international": "00390287119396",
+      "web_site": "https://www.intesa.it/intesaid",
+      "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+    },
+    "lepidaid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
+      "email": "helpdesk@lepida.it",
+      "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+      "phone": "800445500",
+      "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+      "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+      "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+    },
+    "namirialid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
+      "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+      "phone": "003907163494",
+      "web_site": "https://www.namirialtsp.com/spid/",
+      "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+      "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+    },
+    "posteid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+      "helpdesk_form": "https://www.poste.it/scrivici.html",
+      "phone": "800007777",
+      "web_site": "https://posteid.poste.it",
+      "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+      "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+    },
+    "sielteid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
+      "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+      "phone": "00390957171301",
+      "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+      "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+    },
+    "spiditalia": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+      "phone": "+390355787979",
+      "web_site": "https://www.register.it/spid/ ",
+      "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+      "recover_password": "https://spid.register.it/selfcare/recovery/password"
+    },
+    "timid": {
+      "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
+      "email": "supportotimid@telecomitalia.it",
+      "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+      "phone": "800405800",
+      "web_site": "https://spid.tim.it/tim-id-portal",
+      "recover_username": "https://login.id.tim.it/mps/fu.php",
+      "recover_password": "https://login.id.tim.it/mps/fp.php"
     }
   },
   "en": {

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -1328,82 +1328,82 @@
                }
             ]
          }
-      ],
-      "idps": {
-         "arubaid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
-            "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-            "phone": "003905750504",
-            "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-            "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-            "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-            "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-         },
-         "infocertid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of InfoCert by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://help.infocert.it/Cerca?searchText=spid) gathered by your Identity Provider.",
-            "helpdesk_form": "https://contatta.infocert.it/ticket/",
-            "phone": "00390654641489",
-            "web_site": "https://identitadigitale.infocert.it/",
-            "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-            "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-         },
-         "intesaid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Intesa by selecting  one of the options presented below.",
-            "email": "hdintesa@advalia.com",
-            "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-            "phone": "800805093",
-            "phone_international": "00390287119396",
-            "web_site": "https://www.intesa.it/intesaid",
-            "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-         },
-         "lepidaid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Lepida by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://id.lepida.it/docs/manuale_utente.pdf).",
-            "email": "helpdesk@lepida.it",
-            "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-            "phone": "800445500",
-            "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-            "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-            "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-         },
-         "namirialid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Namirial by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) gathered by your Identity Provider.",
-            "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-            "phone": "003907163494",
-            "web_site": "https://www.namirialtsp.com/spid/",
-            "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-            "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-         },
-         "posteid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Poste Italiane by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.poste.it/faq-poste-id.html) gathered by your Identity Provider and the [User Guide](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-            "helpdesk_form": "https://www.poste.it/scrivici.html",
-            "phone": "800007777",
-            "web_site": "https://posteid.poste.it",
-            "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-            "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-         },
-         "sielteid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.sielteid.it/faq.html) gathered by your Identity Provider and the [User Guide](https://www.sielteid.it/faq.html).",
-            "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-            "phone": "00390957171301",
-            "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-            "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-         },
-         "spiditalia": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  the button below. \n For further details you can refer to the [FAQ](https://www.register.it/spid#pgc-23051-10-0) gathered by your Identity Provider and the [User Guide](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-            "phone": "+390355787979",
-            "web_site": "https://www.register.it/spid/ ",
-            "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-            "recover_password": "https://spid.register.it/selfcare/recovery/password"
-         },
-         "timid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Tim by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf).",
-            "email": "supportotimid@telecomitalia.it",
-            "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-            "phone": "800405800",
-            "web_site": "https://spid.tim.it/tim-id-portal",
-            "recover_username": "https://login.id.tim.it/mps/fu.php",
-            "recover_password": "https://login.id.tim.it/mps/fp.php"
-         }
+      ]
+   },
+   "idps": {
+      "arubaid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
+         "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+         "phone": "003905750504",
+         "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+         "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+         "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+         "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+      },
+      "infocertid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of InfoCert by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://help.infocert.it/Cerca?searchText=spid) gathered by your Identity Provider.",
+         "helpdesk_form": "https://contatta.infocert.it/ticket/",
+         "phone": "00390654641489",
+         "web_site": "https://identitadigitale.infocert.it/",
+         "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+         "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+      },
+      "intesaid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Intesa by selecting  one of the options presented below.",
+         "email": "hdintesa@advalia.com",
+         "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+         "phone": "800805093",
+         "phone_international": "00390287119396",
+         "web_site": "https://www.intesa.it/intesaid",
+         "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+      },
+      "lepidaid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Lepida by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://id.lepida.it/docs/manuale_utente.pdf).",
+         "email": "helpdesk@lepida.it",
+         "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+         "phone": "800445500",
+         "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+         "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+         "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+      },
+      "namirialid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Namirial by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) gathered by your Identity Provider.",
+         "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+         "phone": "003907163494",
+         "web_site": "https://www.namirialtsp.com/spid/",
+         "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+         "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+      },
+      "posteid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Poste Italiane by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.poste.it/faq-poste-id.html) gathered by your Identity Provider and the [User Guide](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+         "helpdesk_form": "https://www.poste.it/scrivici.html",
+         "phone": "800007777",
+         "web_site": "https://posteid.poste.it",
+         "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+         "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+      },
+      "sielteid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.sielteid.it/faq.html) gathered by your Identity Provider and the [User Guide](https://www.sielteid.it/faq.html).",
+         "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+         "phone": "00390957171301",
+         "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+         "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+      },
+      "spiditalia": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  the button below. \n For further details you can refer to the [FAQ](https://www.register.it/spid#pgc-23051-10-0) gathered by your Identity Provider and the [User Guide](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+         "phone": "+390355787979",
+         "web_site": "https://www.register.it/spid/ ",
+         "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+         "recover_password": "https://spid.register.it/selfcare/recovery/password"
+      },
+      "timid": {
+         "description": "For problems encountered during the authentication process, you can reach the support desk of Tim by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf).",
+         "email": "supportotimid@telecomitalia.it",
+         "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+         "phone": "800405800",
+         "web_site": "https://spid.tim.it/tim-id-portal",
+         "recover_username": "https://login.id.tim.it/mps/fu.php",
+         "recover_password": "https://login.id.tim.it/mps/fp.php"
       }
    }
 }

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -35,24 +35,14 @@
           },
           {
             "title": "Non riesco ad aggiungere la mia carta. Come mai?",
-            "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n*La tua carta non è abilitata agli acquisti online;\n\n*La tua carta è stata messa “in pausa”;\n\n*Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
+            "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n- La tua carta non è abilitata agli acquisti online;\n\n- La tua carta è stata messa “in pausa”;\n\n- Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento](https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
           }
         ]
       },
       {
         "route_name": "WALLET_PRIVATIVE_DETAIL",
         "title": "La tua carta supermercato",
-        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-        "faqs": [
-          {
-            "title": "Come posso impostare questo metodo di pagamento come preferito?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-          },
-          {
-            "title": "Come posso eliminare questo metodo di pagamento?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-          }
-        ]
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio."
       },
       {
         "route_name": "WALLET_BANCOMAT_DETAIL",
@@ -73,7 +63,7 @@
           },
           {
             "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
-            "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n*Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n*Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
+            "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n- Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n- Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
           }
         ]
       },
@@ -114,7 +104,7 @@
         "faqs": [
           {
             "title": "Come posso pagare su IO?",
-            "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento)."
+            "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento](https://io.italia.it/metodi-pagamento)."
           },
           {
             "title": "Come posso aggiungere un metodo di pagamento?",
@@ -126,7 +116,7 @@
           },
           {
             "title": "Non riesco ad aggiungere un metodo di pagamento. Cosa posso fare?",
-            "body": "Accedi alla pagina [stato aggiunta metodi di pagamento] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
+            "body": "Accedi alla pagina [stato aggiunta metodi di pagamento](ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
           },
           {
             "title": "Come posso eliminare un metodo di pagamento?",
@@ -134,7 +124,7 @@
           },
           {
             "title": "Ho un problema con un pagamento. Cosa posso fare?",
-            "body": "Accedi alla pagina [stato dei tuoi pagamenti] (ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
+            "body": "Accedi alla pagina [stato dei tuoi pagamenti](ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
           },
           {
             "title": "Dove trovo i pagamenti che ho effettuato?",
@@ -150,11 +140,11 @@
           },
           {
             "title": "Che cos’è pagoPA?",
-            "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA] (https://www.pagopa.gov.it/)."
+            "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA](https://www.pagopa.gov.it/)."
           },
           {
             "title": "Come posso saperne di più sui pagamenti digitali?",
-            "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata] (https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti] (https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico] (https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+            "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata](https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico](https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito](https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito](https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata](https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge](https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal](https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
           }
         ]
       },
@@ -212,7 +202,7 @@
           },
           {
             "title": "Non riesco ad aggiungere PayPal come metodo di pagamento.",
-            "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
+            "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1. Controllare che il tuo dispositivo sia connesso a una rete.\n\n1. Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n1. Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
           }
         ]
       },
@@ -515,102 +505,6 @@
         ]
       },
       {
-        "route_name": "BPD_INFORMATION_TOS",
-        "title": "Programma Cashback",
-        "content": "Qui sono visualizzate tutte le informazioni relative al Cashback, il provvedimento istituito dal Ministero dell'Economia e delle Finanze per incentivare l'utilizzo della moneta elettronica anche per piccole somme.",
-        "faqs": [
-          {
-            "title": "Come faccio a richiedere il Cashback?",
-            "body": "Se sei maggiorenne e risiedi in Italia, semplicemente premi sul pulsante 'Attiva il Cashback' in fondo alla pagina e segui il flusso che ti viene proposto.\nA seguito dell'autodichiarazione, ti verrà chiesto di:\n- inserire un IBAN, che utilizzeremo a fine periodo per rimborsarti eventuali importi accumulati;\n- aggiungere metodi di pagamento elettronici (o attivare quelli già presenti nel tuo portafoglio).\n\nEntrambi i passaggi sono facoltativi, ma ti consigliamo di effettuarli subito per evitare di dimenticarti e iniziare quanto prima ad accumulare transazioni valide."
-          },
-          {
-            "title": "Cosa serve per richiedere il Cashback?",
-            "body": "Devi essere maggiorenne, risiedere in Italia e avere almeno un IBAN a te intestato o cointestato e almeno un metodo di pagamento elettronico."
-          },
-          {
-            "title": "Ci sono limiti di reddito? Serve presentare una DSU per il calcolo dell’ISEE per accedere al Cashback?",
-            "body": "No, l’erogazione dei rimborsi previsti dal programma non è legata in alcun modo al reddito né alla situazione patrimoniale dei partecipanti."
-          },
-          {
-            "title": "Possono partecipare tutti i componenti maggiorenni dello stesso nucleo familiare?",
-            "body": "Per aderire al Cashback non c’è un limite al numero di partecipanti per nucleo familiare. Ogni componente maggiorenne e residente in Italia può iscriversi individualmente al programma e ricevere il proprio rimborso."
-          },
-          {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-          }
-        ]
-      },
-      {
-        "route_name": "BPD_DECLARATION",
-        "title": "Iscrizione al Cashback",
-        "content": "Leggi le condizioni descritte in questa pagina e, se corrispondono al vero, spunta i relativi quadratini, premendoli.\nPuoi proseguire nell'attivazione del Cashback solo se tutti e 4 i quadratini sono spuntati.\nTi ricordiamo che dichiarando il falso potrai incorrere in sanzioni penali, oltre a perdere il diritto al rimborso di eventuali importi accumulati ai sensi degli [Articoli 46 e 47 del Dpr 28 dicembre 2000 n. 445](https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:2000-12-28;445)",
-        "faqs": [
-          {
-            "title": "Cosa vuole dire \"acquisti non legati ad attività di Impresa, Arte o Professione\"?",
-            "body": "Significa che non sono valide le transazioni per acquisti legati alla propria attività professionale, ad esempio per l'acquisto di materiale per l'ufficio. I cittadini devono attivare al Cashback solo i metodi di pagamento con cui effettuano acquisti di carattere esclusivamente personale."
-          },
-          {
-            "title": "Per aderire devo avere la cittadinanza italiana?",
-            "body": "No, è sufficiente che tu abbia la residenza in Italia."
-          },
-          {
-            "title": "Mio/a figlio/a è minorenne, ma ha una carta; può partecipare all’iniziativa?",
-            "body": "No, un minorenne non può partecipare al Cashback. Solo se sei il o la titolare della carta di tuo/a figlio/a, puoi registrarla tra i metodi di pagamento elettronici e attivarla sul tuo profilo ai fini del Cashback."
-          }
-        ]
-      },
-      {
-        "route_name": "BPD_ENROLL_PAYMENT_METHODS",
-        "title": "Abilita i tuoi metodi di pagamento al Cashback",
-        "content": "In questa schermata ti mostriamo i metodi di pagamento che hai già registrato nel tuo Portafoglio in IO.\nSeleziona quelli che vuoi attivare per il Cashback – premendo sull'icona grigia alla destra dell'elemento nella lista – e conferma la tua scelta.\nTi ricordiamo che puoi attivare ai fini del Cashback solo i metodi di pagamento **a te intestati.**",
-        "faqs": [
-          {
-            "title": "Cosa vuol dire 'Metodi di pagamento non attivabili o non compatibili'?",
-            "body": "Se nella lista vedi metodi di pagamento sotto questa dicitura, significa che alcuni metodi che hai salvato non possono essere attivati ai fini del Cashback. Puoi toccare la 'i' a fianco di ciascun elemento per leggere la motivazione."
-          },
-          {
-            "title": "Quali metodi di pagamento posso usare per il Cashback?",
-            "body": "Ti invitiamo a controllare la lista completa al seguente link: [Metodi di Pagamento](https://io.italia.it/metodi-pagamento).\nStiamo lavorando per includere quanti più metodi di pagamento elettronico possibile, per cui la lista si potrebbe presto aggiornare!"
-          },
-          {
-            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-          },
-          {
-            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-          },
-          {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-          }
-        ]
-      },
-      {
-        "route_name": "BPD_NO_PAYMENT_METHODS",
-        "title": "Salva i tuoi metodi di pagamento e abilitali al Cashback",
-        "content": "Per iniziare a collezionare transazioni valide che ti permettano di accumulare il cashback, è necessario salvare in IO i tuoi metodi di pagamento elettronico e abilitarli al Cashback.\nPuoi farlo anche in un secondo momento, ma ti informiamo che inizieremo a collezionare le transazioni su un determinato metodo a partire dalle 00:01 del giorno successivo alla sua attivazione in IO.\nTi ricordiamo che puoi attivare ai fini del Cashback solo i metodi di pagamento **a te intestati**.",
-        "faqs": [
-          {
-            "title": "Quali metodi di pagamento posso usare per il Cashback?",
-            "body": "Ti invitiamo a controllare la lista completa al seguente link: [Metodi di Pagamento](https://io.italia.it/metodi-pagamento).\nStiamo lavorando per includere quanti più metodi di pagamento elettronico possibile, per cui la lista si potrebbe presto aggiornare!"
-          },
-          {
-            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)."
-          },
-          {
-            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)."
-          },
-          {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-          }
-        ]
-      },
-      {
         "route_name": "BPD_IBAN",
         "title": "Inserisci il tuo IBAN",
         "content": "In questa schermata puoi inserire l'IBAN di un conto o di una carta dotata di IBAN su cui vuoi ricevere gli eventuali rimborsi a periodo concluso. Il conto o la carta in questione **devono essere intestate o cointestate a te.**\nQuesto passaggio non è obbligatorio, ma ti raccomandiamo di farlo entro la fine del periodo per evitare eventuali problemi con i rimborsi.",
@@ -723,67 +617,6 @@
           {
             "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
             "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
-        "title": "Vuoi iscriverti al programma Cashback?",
-        "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
-        "faqs": [
-          {
-            "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-            "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
-          },
-          {
-            "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
-            "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
-        "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
-        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-        "faqs": [
-          {
-            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-          },
-          {
-            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-          },
-          {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-          },
-          {
-            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
-        "title": "Attiva il Cashback sulle tue carte",
-        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-        "faqs": [
-          {
-            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-          },
-          {
-            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-          },
-          {
-            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-          },
-          {
-            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
           }
         ]
       },
@@ -941,7 +774,7 @@
           },
           {
             "title": "I messaggi possono essere cancellati?",
-            "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
+            "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘**Archiviati**’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘**Archiviati**’."
           },
           {
             "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
@@ -1098,24 +931,14 @@
           },
           {
             "title": "I’m having trouble adding my card. What can I do?",
-            "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n*Your card is not enabled for online purchases; \n\n*Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page] (https://io.italia.it/metodi-pagamento/)."
+            "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n* Your card is not enabled for online purchases; \n\n* Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page](https://io.italia.it/metodi-pagamento/)."
           }
         ]
       },
       {
         "route_name": "WALLET_PRIVATIVE_DETAIL",
         "title": "Your supermarket card",
-        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-        "faqs": [
-          {
-            "title": "How can I set this payment method as favorite?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-          },
-          {
-            "title": "How can I delete this payment method?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-          }
-        ]
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet."
       },
       {
         "route_name": "WALLET_BANCOMAT_DETAIL",
@@ -1136,7 +959,7 @@
           },
           {
             "title": "Why does it say my card is not compatible with in-app payments?",
-            "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n*Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n*Add the second circuit, if your card has the security code and is already enabled for online payments."
+            "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n* Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n* Add the second circuit, if your card has the security code and is already enabled for online payments."
           }
         ]
       },
@@ -1177,7 +1000,7 @@
         "faqs": [
           {
             "title": "How can I pay on IO?",
-            "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page] (https://io.italia.it/metodi-pagamento)."
+            "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page](https://io.italia.it/metodi-pagamento)."
           },
           {
             "title": "How do I add a payment method?",
@@ -1189,7 +1012,7 @@
           },
           {
             "title": "I have trouble adding a payment method. What can I do?",
-            "body": "Go to the [payment method addition status page] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
+            "body": "Go to the [payment method addition status page](ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
           },
           {
             "title": "How can I delete a payment method?",
@@ -1197,7 +1020,7 @@
           },
           {
             "title": "I have trouble with a payment. What can I do?",
-            "body": "Go to [your payment status page] (ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
+            "body": "Go to [your payment status page](ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
           },
           {
             "title": "Where do I find the payments I have made?",
@@ -1213,11 +1036,11 @@
           },
           {
             "title": "What is pagoPA?",
-            "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website] (https://www.pagopa.gov.it/)."
+            "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website](https://www.pagopa.gov.it/)."
           },
           {
             "title": "How can I learn more about digital payments?",
-            "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section] (https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+            "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section](https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card](https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card](https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card](https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card](https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal](https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
           }
         ]
       },

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -723,22 +723,24 @@
                {
                   "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
                   "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
+            "title": "Vuoi iscriverti al programma Cashback?",
+            "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
+            "faqs": [
+               {
+                  "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
+                  "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
                },
                {
-                  "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
-                  "title": "Vuoi iscriverti al programma Cashback?",
-                  "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
-                  "faqs": [
-                     {
-                        "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-                        "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
-                     },
-                     {
-                        "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
-                        "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
-                     }
-                  ]
-               },
+                  "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
+                  "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
+               }
+            ]
+         },
                {
                   "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
                   "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
@@ -984,84 +986,6 @@
                   ]
                }
             ],
-            "idps": {
-               "arubaid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
-                  "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-                  "phone": "003905750504",
-                  "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-                  "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-                  "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-                  "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-               },
-               "infocertid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
-                  "helpdesk_form": "https://contatta.infocert.it/ticket/",
-                  "phone": "00390654641489",
-                  "web_site": "https://identitadigitale.infocert.it/",
-                  "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-                  "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-               },
-               "intesaid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
-                  "email": "hdintesa@advalia.com",
-                  "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-                  "phone": "800805093",
-                  "phone_international": "00390287119396",
-                  "web_site": "https://www.intesa.it/intesaid",
-                  "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-               },
-               "lepidaid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
-                  "email": "helpdesk@lepida.it",
-                  "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-                  "phone": "800445500",
-                  "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-                  "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-                  "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-               },
-               "namirialid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
-                  "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-                  "phone": "003907163494",
-                  "web_site": "https://www.namirialtsp.com/spid/",
-                  "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-                  "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-               },
-               "posteid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-                  "helpdesk_form": "https://www.poste.it/scrivici.html",
-                  "phone": "800007777",
-                  "web_site": "https://posteid.poste.it",
-                  "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-                  "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-               },
-               "sielteid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
-                  "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-                  "phone": "00390957171301",
-                  "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-                  "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-               },
-               "spiditalia": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-                  "phone": "+390355787979",
-                  "web_site": "https://www.register.it/spid/ ",
-                  "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-                  "recover_password": "https://spid.register.it/selfcare/recovery/password"
-               },
-               "timid": {
-                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
-                  "email": "supportotimid@telecomitalia.it",
-                  "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-                  "phone": "800405800",
-                  "web_site": "https://spid.tim.it/tim-id-portal",
-                  "recover_username": "https://login.id.tim.it/mps/fu.php",
-                  "recover_password": "https://login.id.tim.it/mps/fp.php"
-               }
-            }
-         }
-      ],
       "idps": {
          "arubaid": {
             "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
@@ -1404,82 +1328,82 @@
                }
             ]
          }
-      ]
-   },
-   "idps": {
-      "arubaid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
-         "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-         "phone": "003905750504",
-         "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-         "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-         "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-         "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-      },
-      "infocertid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of InfoCert by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://help.infocert.it/Cerca?searchText=spid) gathered by your Identity Provider.",
-         "helpdesk_form": "https://contatta.infocert.it/ticket/",
-         "phone": "00390654641489",
-         "web_site": "https://identitadigitale.infocert.it/",
-         "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-         "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-      },
-      "intesaid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Intesa by selecting  one of the options presented below.",
-         "email": "hdintesa@advalia.com",
-         "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-         "phone": "800805093",
-         "phone_international": "00390287119396",
-         "web_site": "https://www.intesa.it/intesaid",
-         "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-      },
-      "lepidaid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Lepida by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://id.lepida.it/docs/manuale_utente.pdf).",
-         "email": "helpdesk@lepida.it",
-         "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-         "phone": "800445500",
-         "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-         "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-         "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-      },
-      "namirialid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Namirial by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) gathered by your Identity Provider.",
-         "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-         "phone": "003907163494",
-         "web_site": "https://www.namirialtsp.com/spid/",
-         "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-         "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-      },
-      "posteid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Poste Italiane by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.poste.it/faq-poste-id.html) gathered by your Identity Provider and the [User Guide](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-         "helpdesk_form": "https://www.poste.it/scrivici.html",
-         "phone": "800007777",
-         "web_site": "https://posteid.poste.it",
-         "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-         "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-      },
-      "sielteid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.sielteid.it/faq.html) gathered by your Identity Provider and the [User Guide](https://www.sielteid.it/faq.html).",
-         "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-         "phone": "00390957171301",
-         "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-         "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-      },
-      "spiditalia": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  the button below. \n For further details you can refer to the [FAQ](https://www.register.it/spid#pgc-23051-10-0) gathered by your Identity Provider and the [User Guide](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-         "phone": "+390355787979",
-         "web_site": "https://www.register.it/spid/ ",
-         "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-         "recover_password": "https://spid.register.it/selfcare/recovery/password"
-      },
-      "timid": {
-         "description": "For problems encountered during the authentication process, you can reach the support desk of Tim by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf).",
-         "email": "supportotimid@telecomitalia.it",
-         "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-         "phone": "800405800",
-         "web_site": "https://spid.tim.it/tim-id-portal",
-         "recover_username": "https://login.id.tim.it/mps/fu.php",
-         "recover_password": "https://login.id.tim.it/mps/fp.php"
+      ],
+      "idps": {
+         "arubaid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
+            "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+            "phone": "003905750504",
+            "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+            "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+            "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+            "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+         },
+         "infocertid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of InfoCert by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://help.infocert.it/Cerca?searchText=spid) gathered by your Identity Provider.",
+            "helpdesk_form": "https://contatta.infocert.it/ticket/",
+            "phone": "00390654641489",
+            "web_site": "https://identitadigitale.infocert.it/",
+            "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+            "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+         },
+         "intesaid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Intesa by selecting  one of the options presented below.",
+            "email": "hdintesa@advalia.com",
+            "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+            "phone": "800805093",
+            "phone_international": "00390287119396",
+            "web_site": "https://www.intesa.it/intesaid",
+            "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+         },
+         "lepidaid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Lepida by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://id.lepida.it/docs/manuale_utente.pdf).",
+            "email": "helpdesk@lepida.it",
+            "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+            "phone": "800445500",
+            "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+            "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+            "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+         },
+         "namirialid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Namirial by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) gathered by your Identity Provider.",
+            "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+            "phone": "003907163494",
+            "web_site": "https://www.namirialtsp.com/spid/",
+            "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+            "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+         },
+         "posteid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Poste Italiane by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.poste.it/faq-poste-id.html) gathered by your Identity Provider and the [User Guide](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+            "helpdesk_form": "https://www.poste.it/scrivici.html",
+            "phone": "800007777",
+            "web_site": "https://posteid.poste.it",
+            "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+            "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+         },
+         "sielteid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.sielteid.it/faq.html) gathered by your Identity Provider and the [User Guide](https://www.sielteid.it/faq.html).",
+            "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+            "phone": "00390957171301",
+            "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+            "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+         },
+         "spiditalia": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  the button below. \n For further details you can refer to the [FAQ](https://www.register.it/spid#pgc-23051-10-0) gathered by your Identity Provider and the [User Guide](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+            "phone": "+390355787979",
+            "web_site": "https://www.register.it/spid/ ",
+            "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+            "recover_password": "https://spid.register.it/selfcare/recovery/password"
+         },
+         "timid": {
+            "description": "For problems encountered during the authentication process, you can reach the support desk of Tim by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf).",
+            "email": "supportotimid@telecomitalia.it",
+            "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+            "phone": "800405800",
+            "web_site": "https://spid.tim.it/tim-id-portal",
+            "recover_username": "https://login.id.tim.it/mps/fu.php",
+            "recover_password": "https://login.id.tim.it/mps/fp.php"
+         }
       }
    }
 }

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -1,1409 +1,1409 @@
 {
-   "version": 1,
-   "it": {
-      "screens": [
-         {
-            "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
-            "title": "Paga con la tua carta supermercato",
-            "content": "In questa pagina puoi aggiungere la tua carta supermercato come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
-            "faqs": [
-               {
-                  "title": "Quali carte supermercato posso aggiungere?",
-                  "body": "Puoi aggiungere soltanto le carte supermercato che permettono di pagare. Non sono valide le carte supermercato che non consentono di effettuare pagamenti, ma solo di accumulare punti o avere accesso a sconti."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
-            "title": "Paga con la tua carta PagoBANCOMAT",
-            "content": "In questa pagina puoi aggiungere una carta PagoBANCOMAT come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio. Prima di procedere all'aggiunta delle tue carte PagoBANCOMAT, ti invitiamo a leggere l'informativa.",
-            "faqs": [
-               {
-                  "title": "Perché non trovo la mia banca?",
-                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Se premi su “Continua”, IO cercherà tutte le carte PagoBANCOMAT a te intestate sulla base del tuo codice fiscale, che viene recuperato dallo SPID o dalla CIE con cui hai effettuato l'accesso."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ADD_CARD",
-            "title": "Paga con una carta credito, debito o prepagata",
-            "content": "In questa pagina puoi aggiungere una carta di credito, debito o prepagata come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
-            "faqs": [
-               {
-                  "title": "Dove trovo il codice di sicurezza?",
-                  "body": "Il codice di sicurezza, chiamato anche CVV o CVS, è un codice a tre cifre che si trova sul retro della tua carta. Sulle carte American Express si chiama CID, è a quattro cifre e si trova sul fronte. Se non lo trovi, probabilmente la tua carta non è abilitata ai pagamenti online."
-               },
-               {
-                  "title": "Non riesco ad aggiungere la mia carta. Come mai?",
-                  "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n*La tua carta non è abilitata agli acquisti online;\n\n*La tua carta è stata messa “in pausa”;\n\n*Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_PRIVATIVE_DETAIL",
-            "title": "La tua carta supermercato",
-            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-            "faqs": [
-               {
-                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-               },
-               {
-                  "title": "Come posso eliminare questo metodo di pagamento?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_BANCOMAT_DETAIL",
-            "title": "La tua carta PagoBANCOMAT",
-            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-            "faqs": [
-               {
-                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-               },
-               {
-                  "title": "Come posso eliminare questo metodo di pagamento?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-               },
-               {
-                  "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-               },
-               {
-                  "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
-                  "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n*Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n*Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_PAYPAL_DETAIL",
-            "title": "Il tuo account PayPal",
-            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-            "faqs": [
-               {
-                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-               },
-               {
-                  "title": "Come posso eliminare questo metodo di pagamento?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_CREDIT_CARD_DETAIL",
-            "title": "La tua carta",
-            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-            "faqs": [
-               {
-                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-               },
-               {
-                  "title": "Come posso eliminare questo metodo di pagamento?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_HOME",
-            "title": "Cosa puoi fare nel tuo Portafoglio",
-            "content": "Nel Portafoglio trovi i metodi di pagamento che hai aggiunto, i bonus e le iniziative a cui hai aderito e lo storico delle transazioni effettuate con pagoPA, la piattaforma dei pagamenti verso la Pubblica Amministrazione. In questa sezione, puoi anche pagare tutti gli avvisi di pagamento cartacei con il logo pagoPA.",
-            "faqs": [
-               {
-                  "title": "Come posso pagare su IO?",
-                  "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento)."
-               },
-               {
-                  "title": "Come posso aggiungere un metodo di pagamento?",
-                  "body": "Vai al Portafoglio, premi “Aggiungi” e “Metodo di Pagamento”. Poi, seleziona il metodo che vuoi aggiungere e inserisci i dati richiesti."
-               },
-               {
-                  "title": "Quali bonus, sconti o altre iniziative posso richiedere?",
-                  "body": "Vai al Portafoglio, premi “Aggiungi” e “Sconti, bonus e altre iniziative”. Comparirà una lista con tutti i bonus e le iniziative che puoi richiedere tramite l’app IO."
-               },
-               {
-                  "title": "Non riesco ad aggiungere un metodo di pagamento. Cosa posso fare?",
-                  "body": "Accedi alla pagina [stato aggiunta metodi di pagamento] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
-               },
-               {
-                  "title": "Come posso eliminare un metodo di pagamento?",
-                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-               },
-               {
-                  "title": "Ho un problema con un pagamento. Cosa posso fare?",
-                  "body": "Accedi alla pagina [stato dei tuoi pagamenti] (ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
-               },
-               {
-                  "title": "Dove trovo i pagamenti che ho effettuato?",
-                  "body": "Nel Portafoglio trovi una lista che contiene i pagamenti effettuati con successo tramite l’app IO. La lista include anche i pagamenti effettuati tramite il sito o l’app degli enti aderenti, se ti sei autenticato con SPID."
-               },
-               {
-                  "title": "Posso pagare un avviso che non ho ricevuto tramite IO?",
-                  "body": "Sì, se sull’avviso sono presenti il logo pagoPA e il codice QR o il Codice Avviso. Per farlo, vai nel Portafoglio, scansiona il QR o inserisci il Codice Avviso e completa il pagamento."
-               },
-               {
-                  "title": "Che cos’è un codice QR?",
-                  "body": "Il codice QR è un’immagine quadrata composta da elementi bianchi e neri. Se inquadrato dalla fotocamera di un telefono permette di accedere a contenuti digitali, come ad esempio un sito web, un pagamento o un articolo.\n\nIl codice QR che trovi sugli avvisi di pagamento è associato a un Codice Avviso. Se vai al tuo Portafoglio, premi su “Paga un avviso” e inquadri il codice con la fotocamera, puoi pagare l’avviso senza dover inserire manualmente informazioni come causale, cifra o codice fiscale."
-               },
-               {
-                  "title": "Che cos’è pagoPA?",
-                  "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA] (https://www.pagopa.gov.it/)."
-               },
-               {
-                  "title": "Come posso saperne di più sui pagamenti digitali?",
-                  "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata] (https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti] (https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico] (https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
-               }
-            ]
-         },
-         {
-            "route_name": "UADONATION_ROUTES_WEBVIEW",
-            "title": "Donazioni Ucraina",
-            "content": "In questa pagina, puoi fare una donazione alle organizzazioni umanitarie che assistono le vittime civili della crisi in Ucraina.",
-            "faqs": [
-               {
-                  "title": "Come posso donare?",
-                  "body": "Per donare, scegli un’organizzazione umanitaria tra quelle che trovi nella lista. Poi, seleziona l’importo che vuoi donare e premi “Continua”. Usa un metodo di pagamento compatibile o selezionalo dal Portafoglio. Infine, premi “Paga” per completare la donazione."
-               },
-               {
-                  "title": "Con che metodi di pagamento posso fare la donazione?",
-                  "body": "Puoi donare con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard e con conto PayPal."
-               },
-               {
-                  "title": "C'è un importo minimo?",
-                  "body": "Sì, puoi donare da un minimo di 5 € a un massimo di 200 €. Se vuoi donare importi superiori, ripeti la donazione."
-               },
-               {
-                  "title": "La donazione prevede dei costi di commissione?",
-                  "body": "Se doni con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard non hai costi di commissione."
-               },
-               {
-                  "title": "Dopo la donazione, non ho ricevuto nessuna email con la ricevuta. Cosa posso fare?",
-                  "body": "Dopo la donazione, ti invieremo un'email con la ricevuta. Se non la ricevi, guarda nella cartella spam e verifica che l'indirizzo che trovi nella sezione Profilo > I tuoi dati sia corretto. Ti consigliamo di conservare la ricevuta della donazione, insieme alla documentazione originale del versamento (come l'estratto conto della banca o della carta di credito) per fini fiscali."
-               },
-               {
-                  "title": "Rappresento un'organizzazione umanitaria: posso partecipare all'iniziativa?",
-                  "body": "Per avere informazioni su come partecipare all'iniziativa, scrivi un'email a affari.istituzionali@pagopa.it."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_PAYPAL_SEARCH_PSP",
-            "title": "Scegli il gestore della transazione",
-            "content": "Il gestore della transazione, ovvero il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore, può applicare ad ogni pagamento una commissione variabile. In questa pagina, puoi scegliere quale gestore della transazione utilizzare. Potrai modificare questa scelta ad ogni pagamento, scegliendo in base alla commissione proposta.",
-            "faqs": [
-               {
-                  "title": "Cos’è il gestore della transazione?",
-                  "body": "Il gestore della transazione, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), è il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore. Per svolgere questo servizio, il gestore può applicare ogni volta una commissione.\n\npagoPA ti permette di effettuare pagamenti elettronici tramite uno dei gestori della transazione aderenti. È questo il tramite che ti permette di pagare un avviso, una retta, un bollo o un tributo direttamente in app."
-               },
-               {
-                  "title": "Perché devo scegliere il gestore della transazione?",
-                  "body": "Quando effettui un pagamento, IO ti mostra tutti i gestori della transazione che puoi utilizzare, così che tu possa scegliere quello che ti conviene di più a seconda della commissione proposta. Ad incassare questa commissione non è pagoPA, ma il gestore stesso."
-               },
-               {
-                  "title": "Quale gestore devo scegliere?",
-                  "body": "Puoi selezionare il gestore che preferisci, che tu sia cliente o no e anche se non lo hai mai utilizzato prima. La scelta del gestore non è definitiva: puoi modificarla ad ogni pagamento."
-               },
-               {
-                  "title": "A cosa è dovuto il costo della transazione?",
-                  "body": "Per sostenere i costi di gestione e garantire la sicurezza del trasferimento di denaro, ogni gestore della transazione può applicare una commissione variabile. La commissione varia a seconda delle politiche commerciali e delle condizioni contrattuali sottoscritte col gestore che hai scelto. IO ti mostrerà sempre il costo della transazione indicato dal gestore della transazione, per permetterti di scegliere quello più conveniente."
-               },
-               {
-                  "title": "Non riesco ad aggiungere PayPal come metodo di pagamento.",
-                  "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_PAYPAL_START",
-            "title": "Paga con PayPal",
-            "content": "In questa pagina potrai aggiungere PayPal come metodo di pagamento nell’app IO.\n\nPayPal ti permette di pagare senza inserire ogni volta i tuoi dati finanziari. Ti permette anche di collegare il tuo conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.",
-            "faqs": [
-               {
-                  "title": "Cos’è PayPal?",
-                  "body": "PayPal è il servizio che ti consente di pagare, inviare denaro e accettare pagamenti in modo più rapido, semplice e sicuro, senza dover immettere ogni volta i tuoi dati finanziari. Per approfondire o aprire un conto gratuitamente, vai sul sito [paypal.com](https://www.paypal.com/it)."
-               },
-               {
-                  "title": "Come funziona?",
-                  "body": "Per utilizzare PayPal su IO, registrati con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it) e collega la tua carta di credito, di debito, prepagata o il conto corrente.\n\nPoi, aggiungilo come metodo di pagamento nella sezione Portafoglio di IO. Per farlo, ti verranno richiesti l’indirizzo email e la password del tuo conto PayPal. Dovrai inoltre completare l’autenticazione a due fattori utilizzando una modalità a scelta tra app PayPal, SMS o chiamata."
-               },
-               {
-                  "title": "Che vantaggi ho ad utilizzare PayPal per pagare tramite IO?",
-                  "body": "PayPal ti permetterà di autorizzare le operazioni di pagamento in modo semplice e veloce, senza che tu debba inserire i tuoi dati finanziari.\n\nPuoi collegare al tuo conto PayPal non solo la carta di credito, di debito o prepagata, ma anche il conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.\n\n[Scopri qui](https://www.paypal.com/it/smarthelp/article/come-faccio-a-collegare-il-mio-conto-bancario-al-mio-conto-paypal-faq686) come collegare il tuo conto bancario a PayPal."
-               },
-               {
-                  "title": "Non ho un conto PayPal. Come posso crearne uno?",
-                  "body": "Per creare un conto PayPal, devi registrarti con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it). Per farlo, devi essere maggiorenne e collegare almeno un metodo di pagamento."
-               }
-            ]
-         },
-         {
-            "route_name": "MESSAGE_DETAIL",
-            "title": "Dettagli del messaggio",
-            "content": "Qui puoi visualizzare il dettaglio della comunicazione ricevuta da un ente integrato all'app IO. Se hai dubbi o delle domande sul contenuto specifico del messaggio, puoi contattare l'ente utilizzando i recapiti che trovi in fondo a questo messaggio o nella sezione 'Servizi'.",
-            "faqs": [
-               {
-                  "title": "Questo messaggio non ti interessa?",
-                  "body": "Su IO è possibile disattivare la comunicazione dai servizi che non ti interessano in qualsiasi momento: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi)."
-               },
-               {
-                  "title": "C'è un errore nella comunicazione che hai ricevuto?",
-                  "body": "Se pensi che ci sia un errore nel messaggio che hai ricevuto, puoi utilizzare i recapiti di contatto dell'ente erogatore del servizio per fare una segnalazione o chiedere chiarimenti. \nI recapiti sono disponibili dall'area dettagli del messaggio oppure nella sezione 'Servizi' dell'app IO, selezionando lo specifico ente e servizio in questione. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
-               },
-               {
-                  "title": "Questo ente ha il permesso di scriverti?",
-                  "body": "Un ente può inviarti dei messaggi solo se ha una comunicazione specifica da recapitare a te, associata al tuo codice fiscale. Il tuo codice fiscale non viene comunicato dall'app IO all'ente, ma ciascun ente può utilizzare l'app IO per scriverti solo se ha già i tuoi dati (e quindi una relazione con te). \n \nSe non vuoi più ricevere comunicazioni da uno specifico ente, puoi disattivarne i servizi che non ti interessano: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nNella sezione 'Profilo > Preferenze > Gestione servizi' puoi decidere di lasciare accesa la comunicazione di tutti i servizi, oppure scegliere la configurazione manuale per cui dovrai configurare a uno a uno tutti i servizi dalla relativa schermata di dettaglio."
-               },
-               {
-                  "title": "Vuoi contattare l'ente?",
-                  "body": "Dai dettagli del messaggio puoi visualizzare le informazioni relative allo specifico servizio e ente erogatore. Se segui il link al profilo del servizio trovi le informazioni estese, e i recapiti attraverso i quali puoi contattare l'ente erogatore del servizio. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
-               }
-            ]
-         },
-         {
-            "route_name": "SERVICES_HOME",
-            "title": "Cosa puoi fare nei tuoi Servizi",
-            "content": "Qui puoi visualizzare la lista dei servizi nazionali o locali disponibili su IO. \nPremi sul nome di un servizio per visualizzarne i dettagli.",
-            "faqs": [
-               {
-                  "title": "Come gestire i servizi su IO?",
-                  "body": "Utilizza le configurazioni disponibili nella sezione 'Profilo > Preferenze > Gestione servizi', oppure le opzioni contenute nel dettaglio di ciascun servizio per decidere come riceverne le comunicazioni (messaggio in app, notifica push, inoltro del messaggio via e-mail). \n \nAttenzione! Vedere la lista completa dei servizi non significa che ti contatteranno servizi che non ti riguardano: gli enti comunicano con te solo se in possesso del tuo codice fiscale e nel momento in cui hanno necessità di inviarti comunicazioni importanti."
-               },
-               {
-                  "title": "Puoi contattare gli enti tramite IO?",
-                  "body": "Non puoi direttamente contattare gli enti dall'app IO ma puoi visualizzare le loro informazioni di contatto all'interno della sezione 'Servizi', nella scheda di ciascun servizio."
-               }
-            ]
-         },
-         {
-            "route_name": "SERVICE_DETAIL",
-            "title": "Dettagli del Servizio",
-            "content": "In questa schermata puoi visualizzare la descrizione del servizio, l'informativa privacy e condizioni d'uso, i dati di contatto dell'ente o del servizio e puoi configurare le modalità di comunicazione per questo specifico servizio. \n \nRicorda che su IO ti scriveranno solo servizi che hanno qualche informazione personalizzata da comunicarti: non riceverai messaggi di spam o contenuti che non ti riguardano direttamente. \n \nSe vuoi comunque impedire al servizio di contattarti puoi farlo nell'area 'Questo servizio può', disabilitando l'opzione 'Contattarti in app'. \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nDa questa pagina puoi inoltre gestire l'invio di notifiche push e l'inoltro dei messaggi anche al tuo indirizzo e-mail.",
-            "faqs": [
-               {
-                  "title": "Cosa succede se disattivi un servizio?",
-                  "body": "Non riceverai più le comunicazioni di quello specifico servizio nell'app IO. L'ente che eroga il servizio potrà comunque contattarti o essere contattato attraverso altri canali quali sito, email, numero di telefono o ufficio di pertinenza."
-               },
-               {
-                  "title": "Come funzionano le notifiche push?",
-                  "body": "Le notifiche push ti informano che è arrivato un nuovo messaggio nell'app IO, e ti invitano a procedere alla lettura. \n \nSe preferisci disattivarle, disabilita nell'area 'Questo servizio può' l'opzione 'Inviarti notifiche push'. Nella sezione Messaggi potrai comunque distinguere i messaggi non letti grazie al pallino blu."
-               },
-               {
-                  "title": "Come funziona l'inoltro via email dei messaggi?",
-                  "body": "Attivando l'inoltro via email dei messaggi, riceverai all'indirizzo email associato all'app una copia del messaggio che ricevi su IO. \nL'inoltro via mail non è disponibile per alcuni servizi, sulla base di decisioni prese dall'ente in merito alla sensibilità dei contenuti del messaggio stesso."
-               }
-            ]
-         },
-         {
-            "route_name": "PROFILE_PREFERENCES_EMAIL_FORWARDING",
-            "title": "Come gestire l'inoltro dei messaggi",
-            "content": "Qui puoi abilitare o disabilitare l'inoltro al tuo indirizzo e-mail dei messaggi che ricevi su IO."
-         },
-         {
-            "route_name": "PROFILE_PREFERENCES_SERVICES",
-            "title": "Gestisci servizi in app",
-            "content": "Qui puoi decidere come gestire la comunicazione dei servizi. \nL'app IO vuole essere un canale di comunicazione aggiuntivo per gli enti nazionali o locali che hanno qualcosa da dire proprio a te. \nNon manda messaggi broadcast o spam e per questo ti consigliamo di utilizzare la configurazione rapida, mantenendo la comunicazione dei servizi sempre attiva.",
-            "faqs": [
-               {
-                  "title": "Perché dovrei usare la configurazione rapida?",
-                  "body": "Perchè IO manda solo messaggi utili e rivolti proprio a te: gli enti erogatori dei servizi devono conoscere il tuo codice fiscale per poterti scrivere e questo è garanzia del fatto che hanno già una relazione con te. Usando la configurazione rapida non devi pensare a niente e riceverai i messaggi che ti riguardano anche dai servizi che arriveranno in futuro. \nSe decidi comunque di usare la configurazione manuale, sappi che gli enti potranno contattarti attraverso i canali tradizionali a loro disposizione."
-               },
-               {
-                  "title": "Cosa succede se utilizzo la configurazione manuale?",
-                  "body": "La configurazione manuale spegne la comunicazione di tutti i servizi, quelli attualmente presenti e quelli che arriveranno in futuro. \nPer ricevere i messaggi dai servizi che ti interessano dovrai configurarli uno a uno dalle relative schede servizio. \nAttenzione! Spegnendo la comunicazione tramite IO, l'ente che eroga il servizio potrà comunque contattarti attraverso i canali tradizionali disponibili (es. e-mail, posta, SMS)."
-               }
-            ]
-         },
-         {
-            "route_name": "EUCOVIDCERT_CERTIFICATE",
-            "title": "La tua Certificazione Verde COVID-19",
-            "content": "Questo è il messaggio contenente il codice QR e tutte le informazioni relative alla tua Certificazione Verde COVID-19, il documento che attesta un vaccino, l'esito di un tampone o l'avvenuta guarigione da COVID-19 e che permette di circolare in sicurezza in Italia e in Europa",
-            "faqs": [
-               {
-                  "title": "Posso ricevere su IO più di un certificato verde?",
-                  "body": "Sì, ad esempio perchè hai effettuato diversi tamponi, o perchè hai un certificato di guarigione e hai comunque fatto il vaccino."
-               },
-               {
-                  "title": "Come faccio a vedere il certificato se non ho disponibile la connessione ad Internet?",
-                  "body": "IO chiede il QR code dei certificati alla Piattaforma Nazionale DGC ogni volta che apri il relativo messaggio, quindi in quel momento devi essere connesso. Una volta ottenuto il certificato, puoi però salvare il relativo QR code nella galleria immagini del tuo dispositivo con l'apposito pulsante, così da poterlo mostrare all'occorrenza anche in assenza di connessione."
-               },
-               {
-                  "title": "Come faccio a distinguere fra due certificati, ad esempio vaccinazione o un tampone, se vedo solo il QR Code?",
-                  "body": "Quando esibirai il tuo Certificato Verde, chi lo verificherà non dovrà conoscere i tuoi dati sanitari ma solo essere sicuro che sia valido: per questo nessun dato sanitario è visibile nella schemata dove trovi il QR code. Per leggere i dati sanitari relativi al certificato premi il pulsante 'Dettagli'."
-               },
-               {
-                  "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                  "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Il certificato digitale che trovo su IO sostituisce quello cartaceo?",
-                  "body": "La Certificazione verde COVID-19, emessa dalla piattaforma nazionale del Ministero della Salute, è in formato digitale. Su alcuni canali alternativi all'app IO è anche disponibile in versione PDF stampabile per chi desideri averne una copia cartacea. \n In ogni caso, entrambi i formati contengono le stesse informazioni che identificano il tuo certificato (un QR Code e un sigillo elettronico qualificato). Per maggiori dettagli sugli altri canali: [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Perché non vedo più il mio certificato verde su IO?",
-                  "body": "I certificati su IO non scompaiono, restano sempre a disposizione nell'elenco dei messaggi. Quando provi a visualizzare un certificato, questo viene scaricato in tempo reale dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute. In alcuni casi (certificati scaduti o annullati) potresti non vedere più il QR code e le informazioni di dettaglio. Potrai comunque contattare l'assistenza dedicata per avere maggiori informazioni."
-               },
-               {
-                  "title": "Cosa succede se, dopo aver ricevuto il certificato, disattivo IO?",
-                  "body": "Se hai salvato il certificato come immagine sul tuo dispositivo, continuerà ad essere disponibile. Altrimenti potrai scaricarlo nuovamente attraverso gli altri canali disponibili. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Perchè il mio certificato ora risulta non più valido?",
-                  "body": "La durata della validità dei certificati è definita nella piattaforma nazionale del Ministero della Salute, che è responsabile del rilascio dei certificati. Consulta le FAQ dedicate sul sito [dgc.gov.it](https://www.dgc.gov.it/web/faq.html) per maggiori informazioni."
-               },
-               {
-                  "title": "Fino a quando è valido il mio certificato su IO?",
-                  "body": "Il certificato Verde su IO ha la stessa validità dei certificati ottenibili presso gli altri canali. La decisione sulla durata della validità dei certificati è indipendente da IO e spetta alle autorità competenti. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/) ed eventualmente il sito del Ministero della Salute [https://www.salute.gov.it](https://www.salute.gov.it) per maggiori informazioni."
-               },
-               {
-                  "title": "Dove posso salvare il certificato sull'app IO?",
-                  "body": "Premendo il pulsante 'Salva', puoi salvare il QR code del certificato nella galleria immagini del tuo dispositivo per poterlo usare anche se non sei connesso ad internet."
-               },
-               {
-                  "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
-                  "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
-               },
-               {
-                  "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                  "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-               }
-            ]
-         },
-         {
-            "route_name": "EUCOVIDCERT_MARKDOWN_DETAILS",
-            "title": "I dettagli della tua Certificazione Verde COVID-19",
-            "content": "Qui trovi tutte le informazioni relative alla tua Certificazione Verde COVID-19.",
-            "faqs": [
-               {
-                  "title": "Posso ricevere su IO più di un certificato verde?",
-                  "body": "Sì, ad esempio perchè hai effettuato diversi tamponi, o perchè hai un certificato di guarigione e hai comunque fatto il vaccino."
-               },
-               {
-                  "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                  "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Il certificato digitale che trovo su IO sostituisce quello cartaceo?",
-                  "body": "Sì, il certificato digitale e quello cartaceo contengono le stesse informazioni."
-               },
-               {
-                  "title": "Cosa succede se, dopo aver ricevuto il certificato, disattivo IO?",
-                  "body": "Se hai salvato il certificato come immagine sul tuo dispositivo, continuerà ad essere disponibile. Altrimenti potrai scaricarlo nuovamente attraverso gli altri canali disponibili. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Fino a quando è valido il mio certificato su IO?",
-                  "body": "Il certificato Verde su IO ha la stessa validità dei certificati ottenibili presso gli altri canali. La decisione sulla durata della validità dei certificati è indipendente da IO e spetta alle autorità competenti. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/) ed eventualmente il sito del Ministero della Salute [https://www.salute.gov.it](https://www.salute.gov.it) per maggiori informazioni."
-               },
-               {
-                  "title": "Dove posso salvare il certificato sull'app IO?",
-                  "body": "Premendo il pulsante 'Salva', puoi salvare il QR code del certificato nella galleria immagini del tuo dispositivo per poterlo usare anche se non sei connesso ad internet."
-               },
-               {
-                  "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
-                  "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
-               },
-               {
-                  "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                  "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-               }
-            ]
-         },
-         {
-            "route_name": "CGN_INFORMATION_TOS",
-            "title": "Attiva la Carta Giovani Nazionale",
-            "content": "Qui puoi visualizzare tutte le informazioni relative alla Carta Giovani Nazionale, il provvedimento istituito dal Dipartimento per le Politiche Giovanili e il Servizio Civile Universale che dà diritto a sconti e agevolazioni ai giovani residenti in Italia sull'acquisto di determinati beni e servizi.",
-            "faqs": [
-               {
-                  "title": "Come faccio a richiedere la Carta Giovani Nazionale?",
-                  "body": "Se sei maggiorenne e risiedi in Italia, premi sul pulsante 'Richiedi la Carta' in fondo alla pagina e segui le indicazioni in app. L'app IO effettuerà un controllo sulla tua età e, se risulterà idonea, attiverà la Carta Giovani Nazionale."
-               },
-               {
-                  "title": "Cos'è il circuito EYCA?",
-                  "body": "Il circuito EYCA unisce tutte le carte giovani dei Paesi europei e offre agevolazioni in ottica di reciprocità: un giovane italiano con Carta Giovani Nazionale aderente a EYCA può usufruire dei benefici previsti nei Paesi aderenti, così come i giovani stranieri in visita nel nostro Paese, potranno utilizzare le loro carte EYCA presso gli esercenti aderenti a Carta Giovani Nazionale."
-               },
-               {
-                  "title": "Cosa devo fare per aderire a EYCA?",
-                  "body": "L'adesione a EYCA è prevista solo per i giovani fino ai 30 anni compiuti. Se rientri in questa fascia d'età non dovrai fare nulla: sarà IO a comunicare la richiesta ai sistemi di EYCA. Nel dettaglio della tua Carta Giovani Nazionale compariranno il numero di carta e il logo EYCA. Questi dati ti serviranno per accedere alle agevolazioni previste nel circuito europeo."
-               },
-               {
-                  "title": "Quanto tempo passa dal momento della richiesta al momento dell’attivazione della mia Carta Giovani Nazionale?",
-                  "body": "Se possiedi tutti i requisiti che danno diritto alla Carta Giovani Nazionale, l’attivazione è pressoché immediata: in pochi minuti, dal momento della richiesta, IO completa le verifiche necessarie e attiva la tua Carta."
-               },
-               {
-                  "title": "Posso condividere le agevolazioni della Carta Giovani Nazionale con i miei familiari e amici?",
-                  "body": "No, le agevolazioni promosse dalla Carta Giovani Nazionale hanno carattere individuale e nominativo, e possono quindi essere utilizzate esclusivamente dal titolare della Carta. L’uso improprio della carta può comportare la sua revoca."
-               },
-               {
-                  "title": "Devo aggiungere una carta di credito sull’app IO per richiedere e utilizzare la Carta Giovani Nazionale?",
-                  "body": "No, il suo utilizzo non è associato in alcun modo alla disponibilità di una carta di credito né di altri metodi di pagamento salvati nell’app. Quando utilizzerai le agevolazioni della Carta per ottenere uno sconto - sull’e-commerce o presso le strutture fisiche dell’operatore convenzionato - provvederai al pagamento con la modalità che preferisci."
-               },
-               {
-                  "title": "Se utilizzo le agevolazioni della mia Carta Giovani Nazionale per un acquisto online, l’applicazione dello sconto è immediata o riceverò un rimborso successivamente?",
-                  "body": "L’applicazione dello sconto è immediata. Nel caso in cui l’agevolazione preveda l’inserimento di un codice sconto in fase di acquisto, assicurati di digitarlo  correttamente, per vedere subito applicato lo sconto al carrello dell’e-commerce dell’operatore."
-               }
-            ]
-         },
-         {
-            "route_name": "CGN_DETAILS",
-            "title": "La tua Carta Giovani Nazionale",
-            "content": "Questa è la schermata di dettaglio della tua Carta Giovani Nazionale. Da qui puoi visualizzare la lista degli esercenti e delle istituzioni che aderiscono all'iniziativa e le relative agevolazioni, o copiare il tuo numero di carta EYCA se hai tra i 18 e i 30 anni.",
-            "faqs": [
-               {
-                  "title": "Come posso ottenere sconti con la Carta Giovani Nazionale?",
-                  "body": "Per acquisti presso strutture fisiche, apri l'app IO e mostra la Carta Giovani Nazionale prima del pagamento. Per gli acquisti online, copia il codice sconto che trovi nella scheda dell'agevolazione di tuo interesse e incollalo nel campo sconto presente nel portale dell'esercente. Se il codice inserito è corretto, lo sconto verrà automaticamente applicato al tuo carrello."
-               },
-               {
-                  "title": "Cos'è il circuito EYCA?",
-                  "body": "Il circuito EYCA unisce tutte le carte giovani dei Paesi europei e offre agevolazioni in ottica di reciprocità: un giovane italiano con Carta Giovani Nazionale aderente a EYCA può usufruire dei benefici previsti nei Paesi aderenti, così come i giovani stranieri in visita nel nostro Paese, potranno utilizzare le loro carte EYCA presso gli esercenti aderenti a Carta Giovani Nazionale."
-               },
-               {
-                  "title": "Cosa devo fare per aderire a EYCA?",
-                  "body": "L'adesione a EYCA è prevista solo per i giovani fino ai 30 anni compiuti. Se rientri in questa fascia d'età non dovrai fare nulla: sarà IO a comunicare la richiesta ai sistemi di EYCA. Nel dettaglio della tua Carta Giovani Nazionale compariranno il numero di carta e il logo EYCA. Questi dati ti serviranno per accedere alle agevolazioni previste nel circuito europeo."
-               },
-               {
-                  "title": "Quando scade la mia Carta Giovani Nazionale?",
-                  "body": "La tua Carta Giovani Nazionale perde validità al compimento del 36esimo anno di età. La data di scadenza è indicata nel dettaglio della tua Carta sempre consultabile nella sezione “Portafoglio” dell’App. Dopo i 30 anni, in ogni caso, puoi usufruire soltanto delle agevolazioni promosse sul territorio nazionale, dal momento che quelle offerte dal circuito EYCA a livello europeo sono valide fino al compimento del 31° anno di età."
-               },
-               {
-                  "title": "Posso disattivare la mia Carta Giovani Nazionale?",
-                  "body": "Sì. Dalla schermata di dettaglio della CGN premi “Disattiva la tua carta” e conferma. Da quel momento non vedrai più la CGN nel portafoglio. Disattivando la CGN, perdi anche i diritti relativi al circuito EYCA."
-               },
-               {
-                  "title": "Posso condividere le agevolazioni della Carta Giovani Nazionale con i miei familiari e amici?",
-                  "body": "No, le agevolazioni promosse dalla Carta Giovani Nazionale hanno carattere individuale e nominativo, e possono quindi essere utilizzate esclusivamente dal titolare della Carta. L’uso improprio della carta può comportare la sua revoca."
-               },
-               {
-                  "title": "Se utilizzo le agevolazioni della mia Carta Giovani Nazionale per un acquisto online, l’applicazione dello sconto è immediata o riceverò un rimborso successivamente?",
-                  "body": "L’applicazione dello sconto è immediata. Nel caso in cui l’agevolazione preveda l’inserimento di un codice sconto in fase di acquisto, assicurati di digitarlo  correttamente, per vedere subito applicato lo sconto al carrello dell’e-commerce dell’operatore."
-               },
-               {
-                  "title": "Quanti acquisti, online o fisici, posso effettuare usufruendo delle agevolazioni della Carta Giovani Nazionale?",
-                  "body": "L’iniziativa non prevede un limite al numero degli sconti utilizzabili. In ogni caso, ogni operatore convenzionato può disporre autonomamente delle modalità di utilizzo dei codici sconto che mette a disposizione rendendo esplicite eventuali condizioni nella scheda relativa alle proprie agevolazioni, sempre visibile nell’App IO. "
-               }
-            ]
-         },
-         {
-            "route_name": "CGN_MERCHANTS_LIST",
-            "title": "Lista operatori",
-            "content": "Qui puoi visualizzare la lista sempre aggiornata degli esercenti e delle istituzioni che aderiscono all'iniziativa. La lista contiene sia strutture fisiche che operatori online.",
-            "faqs": [
-               {
-                  "title": "Come posso ottenere sconti con la Carta Giovani Nazionale?",
-                  "body": "Per acquisti presso strutture fisiche, apri l'app IO e mostra la Carta Giovani Nazionale prima del pagamento. Per gli acquisti online, copia il codice sconto che trovi nella scheda dell'agevolazione di tuo interesse e incollalo nel campo sconto presente nel portale dell'esercente. Se il codice inserito è corretto, lo sconto verrà automaticamente applicato al tuo carrello."
-               },
-               {
-                  "title": "Perché il codice sconto non funziona?",
-                  "body": "Se il codice non risulta valido: \n\n - verifica di averlo inserito correttamente; \n\n - Assicurati che sia ancora valido: alcuni codici scadono nel giro di poco tempo; \n\n - Controlla nel dettaglio dell'agevolazione se l'operatore applica condizioni relative alle modalità di utilizzo e alla validità dello sconto. \n\n Se il problema persiste o il tuo caso non rientra in quelli descritti, inviaci una richiesta di assistenza."
-               }
-            ]
-         },
-         {
-            "route_name": "CGN_MERCHANTS_DETAIL",
-            "title": "Dettaglio operatore",
-            "content": "In questa schermata trovi tutte le informazioni relative all'operatore che hai selezionato, incluse le agevolazioni in corso di validità.",
-            "faqs": [
-               {
-                  "title": "Come posso ottenere sconti con la Carta Giovani Nazionale?",
-                  "body": "Per acquisti presso strutture fisiche, apri l'app IO e mostra la Carta Giovani Nazionale prima del pagamento. Per gli acquisti online, copia il codice sconto che trovi nella scheda dell'agevolazione di tuo interesse e incollalo nel campo sconto presente nel portale dell'esercente. Se il codice inserito è corretto, lo sconto verrà automaticamente applicato al tuo carrello."
-               },
-               {
-                  "title": "Perché il codice sconto non funziona?",
-                  "body": "Se il codice non risulta valido: \n\n - verifica di averlo inserito correttamente; \n\n - Assicurati che sia ancora valido: alcuni codici scadono nel giro di poco tempo; \n\n - Controlla nel dettaglio dell'agevolazione se l'operatore applica condizioni relative alle modalità di utilizzo e alla validità dello sconto. \n\n Se il problema persiste o il tuo caso non rientra in quelli descritti, inviaci una richiesta di assistenza."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_INFORMATION_TOS",
-            "title": "Programma Cashback",
-            "content": "Qui sono visualizzate tutte le informazioni relative al Cashback, il provvedimento istituito dal Ministero dell'Economia e delle Finanze per incentivare l'utilizzo della moneta elettronica anche per piccole somme.",
-            "faqs": [
-               {
-                  "title": "Come faccio a richiedere il Cashback?",
-                  "body": "Se sei maggiorenne e risiedi in Italia, semplicemente premi sul pulsante 'Attiva il Cashback' in fondo alla pagina e segui il flusso che ti viene proposto.\nA seguito dell'autodichiarazione, ti verrà chiesto di:\n- inserire un IBAN, che utilizzeremo a fine periodo per rimborsarti eventuali importi accumulati;\n- aggiungere metodi di pagamento elettronici (o attivare quelli già presenti nel tuo portafoglio).\n\nEntrambi i passaggi sono facoltativi, ma ti consigliamo di effettuarli subito per evitare di dimenticarti e iniziare quanto prima ad accumulare transazioni valide."
-               },
-               {
-                  "title": "Cosa serve per richiedere il Cashback?",
-                  "body": "Devi essere maggiorenne, risiedere in Italia e avere almeno un IBAN a te intestato o cointestato e almeno un metodo di pagamento elettronico."
-               },
-               {
-                  "title": "Ci sono limiti di reddito? Serve presentare una DSU per il calcolo dell’ISEE per accedere al Cashback?",
-                  "body": "No, l’erogazione dei rimborsi previsti dal programma non è legata in alcun modo al reddito né alla situazione patrimoniale dei partecipanti."
-               },
-               {
-                  "title": "Possono partecipare tutti i componenti maggiorenni dello stesso nucleo familiare?",
-                  "body": "Per aderire al Cashback non c’è un limite al numero di partecipanti per nucleo familiare. Ogni componente maggiorenne e residente in Italia può iscriversi individualmente al programma e ricevere il proprio rimborso."
-               },
-               {
-                  "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                  "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_DECLARATION",
-            "title": "Iscrizione al Cashback",
-            "content": "Leggi le condizioni descritte in questa pagina e, se corrispondono al vero, spunta i relativi quadratini, premendoli.\nPuoi proseguire nell'attivazione del Cashback solo se tutti e 4 i quadratini sono spuntati.\nTi ricordiamo che dichiarando il falso potrai incorrere in sanzioni penali, oltre a perdere il diritto al rimborso di eventuali importi accumulati ai sensi degli [Articoli 46 e 47 del Dpr 28 dicembre 2000 n. 445](https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:2000-12-28;445)",
-            "faqs": [
-               {
-                  "title": "Cosa vuole dire \"acquisti non legati ad attività di Impresa, Arte o Professione\"?",
-                  "body": "Significa che non sono valide le transazioni per acquisti legati alla propria attività professionale, ad esempio per l'acquisto di materiale per l'ufficio. I cittadini devono attivare al Cashback solo i metodi di pagamento con cui effettuano acquisti di carattere esclusivamente personale."
-               },
-               {
-                  "title": "Per aderire devo avere la cittadinanza italiana?",
-                  "body": "No, è sufficiente che tu abbia la residenza in Italia."
-               },
-               {
-                  "title": "Mio/a figlio/a è minorenne, ma ha una carta; può partecipare all’iniziativa?",
-                  "body": "No, un minorenne non può partecipare al Cashback. Solo se sei il o la titolare della carta di tuo/a figlio/a, puoi registrarla tra i metodi di pagamento elettronici e attivarla sul tuo profilo ai fini del Cashback."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_ENROLL_PAYMENT_METHODS",
-            "title": "Abilita i tuoi metodi di pagamento al Cashback",
-            "content": "In questa schermata ti mostriamo i metodi di pagamento che hai già registrato nel tuo Portafoglio in IO.\nSeleziona quelli che vuoi attivare per il Cashback – premendo sull'icona grigia alla destra dell'elemento nella lista – e conferma la tua scelta.\nTi ricordiamo che puoi attivare ai fini del Cashback solo i metodi di pagamento **a te intestati.**",
-            "faqs": [
-               {
-                  "title": "Cosa vuol dire 'Metodi di pagamento non attivabili o non compatibili'?",
-                  "body": "Se nella lista vedi metodi di pagamento sotto questa dicitura, significa che alcuni metodi che hai salvato non possono essere attivati ai fini del Cashback. Puoi toccare la 'i' a fianco di ciascun elemento per leggere la motivazione."
-               },
-               {
-                  "title": "Quali metodi di pagamento posso usare per il Cashback?",
-                  "body": "Ti invitiamo a controllare la lista completa al seguente link: [Metodi di Pagamento](https://io.italia.it/metodi-pagamento).\nStiamo lavorando per includere quanti più metodi di pagamento elettronico possibile, per cui la lista si potrebbe presto aggiornare!"
-               },
-               {
-                  "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                  "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-               },
-               {
-                  "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                  "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-               },
-               {
-                  "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                  "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_NO_PAYMENT_METHODS",
-            "title": "Salva i tuoi metodi di pagamento e abilitali al Cashback",
-            "content": "Per iniziare a collezionare transazioni valide che ti permettano di accumulare il cashback, è necessario salvare in IO i tuoi metodi di pagamento elettronico e abilitarli al Cashback.\nPuoi farlo anche in un secondo momento, ma ti informiamo che inizieremo a collezionare le transazioni su un determinato metodo a partire dalle 00:01 del giorno successivo alla sua attivazione in IO.\nTi ricordiamo che puoi attivare ai fini del Cashback solo i metodi di pagamento **a te intestati**.",
-            "faqs": [
-               {
-                  "title": "Quali metodi di pagamento posso usare per il Cashback?",
-                  "body": "Ti invitiamo a controllare la lista completa al seguente link: [Metodi di Pagamento](https://io.italia.it/metodi-pagamento).\nStiamo lavorando per includere quanti più metodi di pagamento elettronico possibile, per cui la lista si potrebbe presto aggiornare!"
-               },
-               {
-                  "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                  "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)."
-               },
-               {
-                  "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                  "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)."
-               },
-               {
-                  "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                  "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_IBAN",
-            "title": "Inserisci il tuo IBAN",
-            "content": "In questa schermata puoi inserire l'IBAN di un conto o di una carta dotata di IBAN su cui vuoi ricevere gli eventuali rimborsi a periodo concluso. Il conto o la carta in questione **devono essere intestate o cointestate a te.**\nQuesto passaggio non è obbligatorio, ma ti raccomandiamo di farlo entro la fine del periodo per evitare eventuali problemi con i rimborsi.",
-            "faqs": [
-               {
-                  "title": "Posso cambiare l’IBAN con cui ho aderito al Cashback?",
-                  "body": "Sì, puoi modificare l’IBAN in ogni momento fino alla scadenza di ciascun periodo."
-               },
-               {
-                  "title": "Due partecipanti al Cashback possono indicare per i rimborsi lo stesso codice IBAN, se sono co-intestatari?",
-                  "body": "Sì, dal momento che quel codice IBAN risulta associato ai Codici Fiscali di entrambi partecipanti, iscritti individualmente al programma."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_DETAILS",
-            "title": "Cashback",
-            "content": "Qui sono visualizzati i dettagli del Cashback e le azioni necessarie per gestire i tuoi metodi di pagamento associati e l'IBAN per ricevere l'eventuale rimborso. Se vuoi vedere tutte le informazioni relative al programma, visita il sito [io.italia.it/cashback](https://io.italia.it/cashback)",
-            "faqs": [
-               {
-                  "title": "Perché vedo il cashback a cui ho diritto espresso in migliaia?",
-                  "body": "In alcuni dispositivi il messaggio sul cashback a cui hai diritto riporta la cifra in un formato errato: verrà corretto a partire dalla prossima versione dell'app. Il valore corretto è quello riportato nella card del Cashback: ti ricordiamo che in ciascun periodo puoi accumulare al massimo € 150,00 di rimborso."
-               },
-               {
-                  "title": "Come devo leggere questa schermata?",
-                  "body": "Nella card in alto è riportato il periodo relativo al Cashback e se si tratta di un periodo attivo, o concluso. Inoltre l'importo descrive la cifra di Cashback accumulato fino a questo momento. Se vicino all'importo c'è un lucchetto, significa che ancora non si è raggiunto il numero minimo di transazioni richieste.\n\nAppena sotto le statistiche descrivono lo stato e l'andamento nell'iniziativa, ad esempio il numero di transazioni accumulate ed eventualmente la posizione in classifica per ottenere il Super Cashback."
-               },
-               {
-                  "title": "Cosa posso fare in questa schermata?",
-                  "body": "Il modulo relativo ai metodi permette di attivare/disattivare o aggiungere nuovi metodi di pagamento, così come il modulo dell'IBAN permette di inserire o modificare l'IBAN già inserito.\n\nInfine i due pulsanti in basso permettono di visualizzare il dettaglio di tutte le transazioni valide registrate o disiscriversi dal Cashback."
-               },
-               {
-                  "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-                  "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n- carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (_esclusi, quindi, quelli solo per accumulo punti_);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (**sull'App IO a partire dal 2021**).\n\n**Nota bene**: All’avvio del Programma, alcune carte o app di pagamento che utilizzi potrebbero NON essere registrabili da subito, seppur inclusi nelle categorie di cui sopra, o potrebbero essere registrabili solo da un [canale alternativo a IO](https://io.italia.it/cashback/issuer/). Questo potrebbe dipendere dai tempi tecnici necessari per rendere operativi i metodi di pagamento elettronici nell’ambito del Cashback. [Verifica quali metodi di pagamento puoi già attivare per il Cashback](https://io.italia.it/metodi-pagamento/)."
-               },
-               {
-                  "title": "Quali acquisti sono validi ai fini del Cashback?",
-                  "body": "In generale, sono validi gli acquisti effettuati sul territorio nazionale, con i metodi di pagamento elettronico attivati al Cashback, tramite dispositivi fisici di accettazione, come i POS, forniti da [Acquirer Convenzionati che ti permettano di partecipare all’iniziativa](https://io.italia.it/cashback/acquirer). Per questo, prima di eseguire un pagamento verifica sempre con l’esercente se il suo sistema di incasso consente la partecipazione al Cashback. Gli acquisti effettuati con una carta PagoBANCOMAT risulteranno sempre validi a prescindere dal dispositivo di accettazione."
-               },
-               {
-                  "title": "Quando vengono aggiunte transazioni alla lista?",
-                  "body": "Possono passare in media 3 giorni lavorativi. Non vedi ancora la transazione?\n- Controlla se la tua banca ha già contabilizzato la transazione: i dati vengono trasmessi all’app entro 5 giorni lavorativi dalla contabilizzazione.\n- La transazione potrebbe essere stata gestita con il POS di un soggetto (acquirer) [non ancora convenzionato](https://io.italia.it/cashback/acquirer).\n\nRicorda! Quando si aggiunge un nuovo metodo di pagamento, verranno collezionate le transazioni effettuate a partire dalle 00:01 del giorno successivo a quello dell'attivazione."
-               },
-               {
-                  "title": "Perché vedo carte che non riconosco nella sezione 'Attivati su altri canali'?",
-                  "body": "In questa sezione trovi tutti i metodi di pagamento elettronici attivati tramite i canali messi a disposizione dei cosiddetti [Issuer Convenzionati](https://io.italia.it/cashback/issuer).\nAlcuni operatori consentono anche l’aggiunta delle rispettive carte abilitate attraverso i cosiddetti 'wallet' come **Apple Pay, Google Pay o Samsung Pay**.\n\n**In questo periodo sperimentale**, detto 'Extra Cashback di Natale', potresti vedere perciò dei numeri di carta differenti rispetto a quello che vedi sulla carta fisica.\n\nTi assicuriamo che non c’è nessun errore o problema di privacy: **si tratta delle versioni virtuali associate alla tua carta**, composte da codici casuali (detti in gergo tecnico 'token'), utilizzati per mettere in sicurezza i pagamenti che effettui tramite smartphone.\n\nPer questo motivo, ad ogni transazione effettuata con il tuo smartphone, non viene mostrato all’esercente il numero della carta fisica, ma si ricorre a questo tipo di versione 'cifrata' (detta anche 'tokenizzata').\n\nStiamo lavorando con i soggetti del settore dei pagamenti coinvolti nell’iniziativa per migliorare la visualizzazione sull’app IO di questo tipo di carte.\n\nPer maggiori informazioni puoi rivolgerti all’[Issuer Convenzionato](https://io.italia.it/cashback/issuer) con cui hai attivato la tua carta per il Cashback."
-               },
-               {
-                  "title": "Posso cambiare l’IBAN con cui ho aderito al Cashback?",
-                  "body": "Sì, puoi modificare l’IBAN in ogni momento fino alla scadenza di ciascun periodo."
-               },
-               {
-                  "title": "Sono validi anche gli acquisti effettuati con una carta aziendale?",
-                  "body": "No, solo quelli a carattere privato. Le spese che rispondono a esigenze lavorative, professionali o aziendali non sono valide ai fini del Cashback."
-               },
-               {
-                  "title": "Qual è l'importo massimo del Cashback che posso ottenere?",
-                  "body": "Il rimborso è pari al 10% dell’importo di ogni transazione valida ai fini del programma, effettuata durante uno dei periodi previsti. L’importo considerato per singola transazione è di massimo 150 euro, mentre non è previsto un importo minimo.\nIl rimborso massimo che puoi ottenere in ciascun periodo è pari a 150 euro. Ad esempio, se hai effettuato:\n- una spesa di 20 euro, l’importo ottenuto per il Cashback sarà di 2 euro;\n- una spesa di 150 euro, l’importo accumulato sarà di 15 euro;\n- una spesa superiore a 150 euro, ad esempio di 700 euro, accumulerai comunque 15 euro di Cashback.\nNell’app IO è sempre possibile visualizzare l’importo del Cashback accumulato fino a quel momento e il dettaglio delle singole transazioni che lo hanno generato. Come già scritto, l’importo massimo che puoi ottenere per singolo periodo è di 150 euro, per cui una volta raggiunto questo limite, eventuali nuove transazioni non genereranno ulteriori rimborsi."
-               },
-               {
-                  "title": "Quando riceverò il rimborso ottenuto sul mio conto corrente?",
-                  "body": "I rimborsi sono erogati entro 60 giorni dal termine del periodo, con un bonifico sull’IBAN che hai comunicato."
-               },
-               {
-                  "title": "Se sono iscritto al Cashback in un certo periodo, resterò iscritto anche per il periodo successivo?",
-                  "body": "Sì, considera, però, che al termine di ciascun periodo si conclude il calcolo delle transazioni che ti consentono di ottenere i relativi rimborsi e si riparte da zero all’avvio del periodo successivo. In ogni momento hai la possibilità di attivare o disattivare i tuoi metodi di pagamento o di cancellarti dal programma."
-               },
-               {
-                  "title": "Cosa succede se mi cancello dal programma?",
-                  "body": "La cancellazione dal programma comporta la perdita del diritto ai rimborsi per il periodo in corso. Se non vuoi perdere i rimborsi accumulati, devi aspettare che ti vengano accreditati sull’IBAN che hai comunicato (solitamente entro 60 giorni successivi alla fine di ciascun periodo)."
-               }
-            ]
-         },
-         {
-            "route_name": "BPD_TRANSACTIONS",
-            "title": "Le tue transazioni valide ai fini del Cashback",
-            "content": "In questa pagina sono visualizzate tutte le transazioni che ti hanno permesso di accumulare dei rimborsi, o di acquisire posizioni nella classifica del Super Cashback (a partire da gennaio 2021).\n\nPremendo su una transazione si apre un dettaglio con maggiori informazioni.\n\nI dati relativi alle transazioni non contengono informazioni circa il tipo di esercente presso cui è avvenuta.",
-            "faqs": [
-               {
-                  "title": "Quali acquisti sono validi ai fini del Cashback?",
-                  "body": "In generale, sono validi gli acquisti effettuati sul territorio nazionale, con i metodi di pagamento elettronico attivati al Cashback, tramite dispositivi fisici di accettazione, come i POS, forniti da [Acquirer Convenzionati che ti permettano di partecipare all’iniziativa](https://io.italia.it/cashback/acquirer). Per questo, prima di eseguire un pagamento verifica sempre con l’esercente se il suo sistema di incasso consente la partecipazione al Cashback. Gli acquisti effettuati con una carta PagoBANCOMAT risulteranno sempre validi a prescindere dal dispositivo di accettazione."
-               },
-               {
-                  "title": "Quando vengono aggiunte transazioni alla lista?",
-                  "body": "Possono passare in media 3 giorni lavorativi. Non vedi ancora la transazione?\n- Controlla se la tua banca ha già contabilizzato la transazione: i dati vengono trasmessi all’app entro 5 giorni lavorativi dalla contabilizzazione.\n- La transazione potrebbe essere stata gestita con il POS di un soggetto (acquirer) [non ancora convenzionato](https://io.italia.it/cashback/acquirer).\n\nRicorda! Quando si aggiunge un nuovo metodo di pagamento, verranno collezionate le transazioni effettuate a partire dalle 00:01 del giorno successivo a quello dell'attivazione."
-               },
-               {
-                  "title": "Perché vedo carte che non riconosco nella lista delle transazioni?",
-                  "body": "Alcuni operatori consentono anche l’aggiunta delle rispettive carte abilitate attraverso i cosiddetti 'wallet' come **Apple Pay, Google Pay o Samsung Pay**.\n\n**In questo periodo sperimentale**, detto 'Extra Cashback di Natale', potresti vedere perciò dei numeri di carta differenti rispetto a quello che vedi sulla carta fisica.\n\nTi assicuriamo che non c’è nessun errore o problema di privacy: **si tratta delle versioni virtuali associate alla tua carta**, composte da codici casuali (detti in gergo tecnico 'token'), utilizzati per mettere in sicurezza i pagamenti che effettui tramite smartphone.\n\nPer questo motivo, ad ogni transazione effettuata con il tuo smartphone, non viene mostrato all’esercente il numero della carta fisica, ma si ricorre a questo tipo di versione 'cifrata' (detta anche 'tokenizzata').\n\nStiamo lavorando con i soggetti del settore dei pagamenti coinvolti nell’iniziativa per migliorare la visualizzazione sull’app IO di questo tipo di carte.\n\nPer maggiori informazioni puoi rivolgerti all’[Issuer Convenzionato](https://io.italia.it/cashback/issuer) con cui hai attivato la tua carta per il Cashback."
-               },
-               {
-                  "title": "Perché vedo una transazione con €0 di cashback?",
-                  "body": "Se alcune transazioni della lista mostrano €0 come cashback accumulato, significa che probabilmente hai già raggiunto il massimo importo di Cashback ottenibile. Tutte le transazioni collezionate dopo aver raggiunto il traguardo, frutteranno €0, ma contribuiranno alla tua posizione per ottenere il Super Cashback, se attivo nel periodo corrente."
-               },
-               {
-                  "title": "C’è un importo minimo sugli acquisti per far sì che le transazioni vengano conteggiate?",
-                  "body": "No, per le transazioni **non è previsto un importo minimo**. Ma, nel caso del rimborso percentuale (Cashback 10%), l’importo massimo ottenibile per singola transazione è 15 euro, anche se la transazione supera i 150 euro."
-               },
-               {
-                  "title": "C’è un numero massimo di acquisti (nell’arco di una giornata o per la durata di un periodo del programma), oltre il quale le transazioni non sono più conteggiate per il Cashback?",
-                  "body": "No, non c’è un numero massimo di acquisti. Esiste però un importo massimo dei rimborsi che puoi ottenere, ovvero 150 euro per ciascun periodo. Una volta raggiunto l’importo massimo, le nuove transazioni concorreranno alla tua posizione nella classifica del Super Cashback (da gennaio 2021). [Consulta la Guida per saperne di più](https://io.italia.it/cashback/guida)"
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_SEARCH_AVAILABLE_USER_BANCOMAT",
-            "title": "Le tue carte PagoBANCOMAT",
-            "content": "In questa schermata ti mostriamo la o le carte PagoBANCOMAT a te intestate. Puoi aggiungerle premendo 'Aggiungi', oppure saltare la carta in questione per uscire dal flusso o passare alla carta successiva nel caso ne siano state trovate più di una.",
-            "faqs": [
-               {
-                  "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
-            "title": "Vuoi iscriverti al programma Cashback?",
-            "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
-            "faqs": [
-               {
-                  "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-                  "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
-               },
-               {
-                  "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
-                  "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
-               }
-            ]
-         },
-               {
-                  "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
-                  "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
-                  "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-                  "faqs": [
-                     {
-                        "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                        "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-                     },
-                     {
-                        "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                        "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-                     },
-                     {
-                        "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                        "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-                     },
-                     {
-                        "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                        "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-                     }
-                  ]
-               },
-               {
-                  "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
-                  "title": "Attiva il Cashback sulle tue carte",
-                  "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-                  "faqs": [
-                     {
-                        "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                        "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-                     },
-                     {
-                        "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                        "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-                     },
-                     {
-                        "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                        "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-                     },
-                     {
-                        "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                        "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-                     }
-                  ]
-               },
-               {
-                  "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
-                  "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-                  "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
-                  "faqs": [
-                     {
-                        "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
-                        "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
-                     },
-                     {
-                        "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
-                        "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
-                     },
-                     {
-                        "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-                        "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-                     }
-                  ]
-               },
-               {
-                  "route_name": "WALLET_ONBOARDING_COBADGE_START",
-                  "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-                  "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
-                  "faqs": [
-                     {
-                        "title": "Posso aggiungere anche carte con circuito internazionale?",
-                        "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
-                     },
-                     {
-                        "title": "Perché non trovo alcuna carta?",
-                        "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
-                     }
-                  ]
-               },
-               {
-                  "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
-                  "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-                  "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
-                  "faqs": [
-                     {
-                        "title": "Perché la data di scadenza è diversa?",
-                        "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-                     },
-                     {
-                        "title": "Perché il numero della carta è diverso?",
-                        "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-                     },
-                     {
-                        "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-                        "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-                     }
-                  ]
-               },
-               {
-                  "route_name": "WALLET_COBADGE_DETAIL",
-                  "title": "La tua carta con circuito internazionale",
-                  "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
-                  "faqs": [
-                     {
-                        "title": "Cosa posso fare da qui?",
-                        "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
-                     },
-                     {
-                        "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-                        "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-                     },
-                     {
-                        "title": "Perché la data di scadenza è diversa?",
-                        "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-                     },
-                     {
-                        "title": "Perché il numero della carta è diverso?",
-                        "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-                     }
-                  ]
-               },
-               {
-                  "route_name": "AUTHENTICATION_LANDING",
-                  "title": "Come accedere all'app IO",
-                  "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
-                  "faqs": [
-                     {
-                        "title": "Cos'è SPID?",
-                        "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
-                     },
-                     {
-                        "title": "Come puoi ottenere SPID?",
-                        "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
-                     },
-                     {
-                        "title": "Hai perso le tue credenziali SPID?",
-                        "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
-                     },
-                     {
-                        "title": "Cos'è la CIE?",
-                        "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
-                     },
-                     {
-                        "title": "Come puoi ottenere la CIE?",
-                        "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
-                     },
-                     {
-                        "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-                        "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-                     },
-                     {
-                        "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-                        "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                        "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
-                        "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
-                     },
-                     {
-                        "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-                        "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-                        "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
-                        "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
-                     },
-                     {
-                        "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                        "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Usi Android e non riesci ad aggiornare IO?",
-                        "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-                     }
-                  ]
-               },
-               {
-                  "route_name": "MESSAGES_HOME",
-                  "title": "Cosa puoi fare nei tuoi Messaggi",
-                  "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
-                  "faqs": [
-                     {
-                        "title": "Che tipo di messaggi posso ricevere?",
-                        "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
-                     },
-                     {
-                        "title": "Cosa succede se archivio i messaggi?",
-                        "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
-                     },
-                     {
-                        "title": "I messaggi possono essere cancellati?",
-                        "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
-                     },
-                     {
-                        "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-                        "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-                     },
-                     {
-                        "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-                        "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                        "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
-                        "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-                     },
-                     {
-                        "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
-                        "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-                     },
-                     {
-                        "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-                        "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
-                        "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-                        "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                        "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-                     },
-                     {
-                        "title": "Usi Android e non riesci ad aggiornare IO?",
-                        "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-                     }
-                  ]
-               }
-            ],
-      "idps": {
-         "arubaid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
-            "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-            "phone": "003905750504",
-            "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-            "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-            "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-            "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-         },
-         "infocertid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
-            "helpdesk_form": "https://contatta.infocert.it/ticket/",
-            "phone": "00390654641489",
-            "web_site": "https://identitadigitale.infocert.it/",
-            "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-            "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-         },
-         "intesaid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
-            "email": "hdintesa@advalia.com",
-            "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-            "phone": "800805093",
-            "phone_international": "00390287119396",
-            "web_site": "https://www.intesa.it/intesaid",
-            "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-         },
-         "lepidaid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
-            "email": "helpdesk@lepida.it",
-            "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-            "phone": "800445500",
-            "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-            "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-            "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-         },
-         "namirialid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
-            "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-            "phone": "003907163494",
-            "web_site": "https://www.namirialtsp.com/spid/",
-            "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-            "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-         },
-         "posteid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-            "helpdesk_form": "https://www.poste.it/scrivici.html",
-            "phone": "800007777",
-            "web_site": "https://posteid.poste.it",
-            "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-            "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-         },
-         "sielteid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
-            "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-            "phone": "00390957171301",
-            "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-            "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-         },
-         "spiditalia": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-            "phone": "+390355787979",
-            "web_site": "https://www.register.it/spid/ ",
-            "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-            "recover_password": "https://spid.register.it/selfcare/recovery/password"
-         },
-         "timid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
-            "email": "supportotimid@telecomitalia.it",
-            "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-            "phone": "800405800",
-            "web_site": "https://spid.tim.it/tim-id-portal",
-            "recover_username": "https://login.id.tim.it/mps/fu.php",
-            "recover_password": "https://login.id.tim.it/mps/fp.php"
-         }
+  "version": 1,
+  "it": {
+    "screens": [
+      {
+        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+        "title": "Paga con la tua carta supermercato",
+        "content": "In questa pagina puoi aggiungere la tua carta supermercato come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
+        "faqs": [
+          {
+            "title": "Quali carte supermercato posso aggiungere?",
+            "body": "Puoi aggiungere soltanto le carte supermercato che permettono di pagare. Non sono valide le carte supermercato che non consentono di effettuare pagamenti, ma solo di accumulare punti o avere accesso a sconti."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
+        "title": "Paga con la tua carta PagoBANCOMAT",
+        "content": "In questa pagina puoi aggiungere una carta PagoBANCOMAT come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio. Prima di procedere all'aggiunta delle tue carte PagoBANCOMAT, ti invitiamo a leggere l'informativa.",
+        "faqs": [
+          {
+            "title": "Perché non trovo la mia banca?",
+            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Se premi su “Continua”, IO cercherà tutte le carte PagoBANCOMAT a te intestate sulla base del tuo codice fiscale, che viene recuperato dallo SPID o dalla CIE con cui hai effettuato l'accesso."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ADD_CARD",
+        "title": "Paga con una carta credito, debito o prepagata",
+        "content": "In questa pagina puoi aggiungere una carta di credito, debito o prepagata come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
+        "faqs": [
+          {
+            "title": "Dove trovo il codice di sicurezza?",
+            "body": "Il codice di sicurezza, chiamato anche CVV o CVS, è un codice a tre cifre che si trova sul retro della tua carta. Sulle carte American Express si chiama CID, è a quattro cifre e si trova sul fronte. Se non lo trovi, probabilmente la tua carta non è abilitata ai pagamenti online."
+          },
+          {
+            "title": "Non riesco ad aggiungere la mia carta. Come mai?",
+            "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n*La tua carta non è abilitata agli acquisti online;\n\n*La tua carta è stata messa “in pausa”;\n\n*Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_PRIVATIVE_DETAIL",
+        "title": "La tua carta supermercato",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_BANCOMAT_DETAIL",
+        "title": "La tua carta PagoBANCOMAT",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          },
+          {
+            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+          },
+          {
+            "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
+            "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n*Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n*Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_PAYPAL_DETAIL",
+        "title": "Il tuo account PayPal",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_CREDIT_CARD_DETAIL",
+        "title": "La tua carta",
+        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+        "faqs": [
+          {
+            "title": "Come posso impostare questo metodo di pagamento come preferito?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+          },
+          {
+            "title": "Come posso eliminare questo metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_HOME",
+        "title": "Cosa puoi fare nel tuo Portafoglio",
+        "content": "Nel Portafoglio trovi i metodi di pagamento che hai aggiunto, i bonus e le iniziative a cui hai aderito e lo storico delle transazioni effettuate con pagoPA, la piattaforma dei pagamenti verso la Pubblica Amministrazione. In questa sezione, puoi anche pagare tutti gli avvisi di pagamento cartacei con il logo pagoPA.",
+        "faqs": [
+          {
+            "title": "Come posso pagare su IO?",
+            "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento)."
+          },
+          {
+            "title": "Come posso aggiungere un metodo di pagamento?",
+            "body": "Vai al Portafoglio, premi “Aggiungi” e “Metodo di Pagamento”. Poi, seleziona il metodo che vuoi aggiungere e inserisci i dati richiesti."
+          },
+          {
+            "title": "Quali bonus, sconti o altre iniziative posso richiedere?",
+            "body": "Vai al Portafoglio, premi “Aggiungi” e “Sconti, bonus e altre iniziative”. Comparirà una lista con tutti i bonus e le iniziative che puoi richiedere tramite l’app IO."
+          },
+          {
+            "title": "Non riesco ad aggiungere un metodo di pagamento. Cosa posso fare?",
+            "body": "Accedi alla pagina [stato aggiunta metodi di pagamento] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
+          },
+          {
+            "title": "Come posso eliminare un metodo di pagamento?",
+            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+          },
+          {
+            "title": "Ho un problema con un pagamento. Cosa posso fare?",
+            "body": "Accedi alla pagina [stato dei tuoi pagamenti] (ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
+          },
+          {
+            "title": "Dove trovo i pagamenti che ho effettuato?",
+            "body": "Nel Portafoglio trovi una lista che contiene i pagamenti effettuati con successo tramite l’app IO. La lista include anche i pagamenti effettuati tramite il sito o l’app degli enti aderenti, se ti sei autenticato con SPID."
+          },
+          {
+            "title": "Posso pagare un avviso che non ho ricevuto tramite IO?",
+            "body": "Sì, se sull’avviso sono presenti il logo pagoPA e il codice QR o il Codice Avviso. Per farlo, vai nel Portafoglio, scansiona il QR o inserisci il Codice Avviso e completa il pagamento."
+          },
+          {
+            "title": "Che cos’è un codice QR?",
+            "body": "Il codice QR è un’immagine quadrata composta da elementi bianchi e neri. Se inquadrato dalla fotocamera di un telefono permette di accedere a contenuti digitali, come ad esempio un sito web, un pagamento o un articolo.\n\nIl codice QR che trovi sugli avvisi di pagamento è associato a un Codice Avviso. Se vai al tuo Portafoglio, premi su “Paga un avviso” e inquadri il codice con la fotocamera, puoi pagare l’avviso senza dover inserire manualmente informazioni come causale, cifra o codice fiscale."
+          },
+          {
+            "title": "Che cos’è pagoPA?",
+            "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA] (https://www.pagopa.gov.it/)."
+          },
+          {
+            "title": "Come posso saperne di più sui pagamenti digitali?",
+            "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata] (https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti] (https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico] (https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+          }
+        ]
+      },
+      {
+        "route_name": "UADONATION_ROUTES_WEBVIEW",
+        "title": "Donazioni Ucraina",
+        "content": "In questa pagina, puoi fare una donazione alle organizzazioni umanitarie che assistono le vittime civili della crisi in Ucraina.",
+        "faqs": [
+          {
+            "title": "Come posso donare?",
+            "body": "Per donare, scegli un’organizzazione umanitaria tra quelle che trovi nella lista. Poi, seleziona l’importo che vuoi donare e premi “Continua”. Usa un metodo di pagamento compatibile o selezionalo dal Portafoglio. Infine, premi “Paga” per completare la donazione."
+          },
+          {
+            "title": "Con che metodi di pagamento posso fare la donazione?",
+            "body": "Puoi donare con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard e con conto PayPal."
+          },
+          {
+            "title": "C'è un importo minimo?",
+            "body": "Sì, puoi donare da un minimo di 5 € a un massimo di 200 €. Se vuoi donare importi superiori, ripeti la donazione."
+          },
+          {
+            "title": "La donazione prevede dei costi di commissione?",
+            "body": "Se doni con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard non hai costi di commissione."
+          },
+          {
+            "title": "Dopo la donazione, non ho ricevuto nessuna email con la ricevuta. Cosa posso fare?",
+            "body": "Dopo la donazione, ti invieremo un'email con la ricevuta. Se non la ricevi, guarda nella cartella spam e verifica che l'indirizzo che trovi nella sezione Profilo > I tuoi dati sia corretto. Ti consigliamo di conservare la ricevuta della donazione, insieme alla documentazione originale del versamento (come l'estratto conto della banca o della carta di credito) per fini fiscali."
+          },
+          {
+            "title": "Rappresento un'organizzazione umanitaria: posso partecipare all'iniziativa?",
+            "body": "Per avere informazioni su come partecipare all'iniziativa, scrivi un'email a affari.istituzionali@pagopa.it."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_PAYPAL_SEARCH_PSP",
+        "title": "Scegli il gestore della transazione",
+        "content": "Il gestore della transazione, ovvero il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore, può applicare ad ogni pagamento una commissione variabile. In questa pagina, puoi scegliere quale gestore della transazione utilizzare. Potrai modificare questa scelta ad ogni pagamento, scegliendo in base alla commissione proposta.",
+        "faqs": [
+          {
+            "title": "Cos’è il gestore della transazione?",
+            "body": "Il gestore della transazione, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), è il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore. Per svolgere questo servizio, il gestore può applicare ogni volta una commissione.\n\npagoPA ti permette di effettuare pagamenti elettronici tramite uno dei gestori della transazione aderenti. È questo il tramite che ti permette di pagare un avviso, una retta, un bollo o un tributo direttamente in app."
+          },
+          {
+            "title": "Perché devo scegliere il gestore della transazione?",
+            "body": "Quando effettui un pagamento, IO ti mostra tutti i gestori della transazione che puoi utilizzare, così che tu possa scegliere quello che ti conviene di più a seconda della commissione proposta. Ad incassare questa commissione non è pagoPA, ma il gestore stesso."
+          },
+          {
+            "title": "Quale gestore devo scegliere?",
+            "body": "Puoi selezionare il gestore che preferisci, che tu sia cliente o no e anche se non lo hai mai utilizzato prima. La scelta del gestore non è definitiva: puoi modificarla ad ogni pagamento."
+          },
+          {
+            "title": "A cosa è dovuto il costo della transazione?",
+            "body": "Per sostenere i costi di gestione e garantire la sicurezza del trasferimento di denaro, ogni gestore della transazione può applicare una commissione variabile. La commissione varia a seconda delle politiche commerciali e delle condizioni contrattuali sottoscritte col gestore che hai scelto. IO ti mostrerà sempre il costo della transazione indicato dal gestore della transazione, per permetterti di scegliere quello più conveniente."
+          },
+          {
+            "title": "Non riesco ad aggiungere PayPal come metodo di pagamento.",
+            "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_PAYPAL_START",
+        "title": "Paga con PayPal",
+        "content": "In questa pagina potrai aggiungere PayPal come metodo di pagamento nell’app IO.\n\nPayPal ti permette di pagare senza inserire ogni volta i tuoi dati finanziari. Ti permette anche di collegare il tuo conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.",
+        "faqs": [
+          {
+            "title": "Cos’è PayPal?",
+            "body": "PayPal è il servizio che ti consente di pagare, inviare denaro e accettare pagamenti in modo più rapido, semplice e sicuro, senza dover immettere ogni volta i tuoi dati finanziari. Per approfondire o aprire un conto gratuitamente, vai sul sito [paypal.com](https://www.paypal.com/it)."
+          },
+          {
+            "title": "Come funziona?",
+            "body": "Per utilizzare PayPal su IO, registrati con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it) e collega la tua carta di credito, di debito, prepagata o il conto corrente.\n\nPoi, aggiungilo come metodo di pagamento nella sezione Portafoglio di IO. Per farlo, ti verranno richiesti l’indirizzo email e la password del tuo conto PayPal. Dovrai inoltre completare l’autenticazione a due fattori utilizzando una modalità a scelta tra app PayPal, SMS o chiamata."
+          },
+          {
+            "title": "Che vantaggi ho ad utilizzare PayPal per pagare tramite IO?",
+            "body": "PayPal ti permetterà di autorizzare le operazioni di pagamento in modo semplice e veloce, senza che tu debba inserire i tuoi dati finanziari.\n\nPuoi collegare al tuo conto PayPal non solo la carta di credito, di debito o prepagata, ma anche il conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.\n\n[Scopri qui](https://www.paypal.com/it/smarthelp/article/come-faccio-a-collegare-il-mio-conto-bancario-al-mio-conto-paypal-faq686) come collegare il tuo conto bancario a PayPal."
+          },
+          {
+            "title": "Non ho un conto PayPal. Come posso crearne uno?",
+            "body": "Per creare un conto PayPal, devi registrarti con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it). Per farlo, devi essere maggiorenne e collegare almeno un metodo di pagamento."
+          }
+        ]
+      },
+      {
+        "route_name": "MESSAGE_DETAIL",
+        "title": "Dettagli del messaggio",
+        "content": "Qui puoi visualizzare il dettaglio della comunicazione ricevuta da un ente integrato all'app IO. Se hai dubbi o delle domande sul contenuto specifico del messaggio, puoi contattare l'ente utilizzando i recapiti che trovi in fondo a questo messaggio o nella sezione 'Servizi'.",
+        "faqs": [
+          {
+            "title": "Questo messaggio non ti interessa?",
+            "body": "Su IO è possibile disattivare la comunicazione dai servizi che non ti interessano in qualsiasi momento: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi)."
+          },
+          {
+            "title": "C'è un errore nella comunicazione che hai ricevuto?",
+            "body": "Se pensi che ci sia un errore nel messaggio che hai ricevuto, puoi utilizzare i recapiti di contatto dell'ente erogatore del servizio per fare una segnalazione o chiedere chiarimenti. \nI recapiti sono disponibili dall'area dettagli del messaggio oppure nella sezione 'Servizi' dell'app IO, selezionando lo specifico ente e servizio in questione. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
+          },
+          {
+            "title": "Questo ente ha il permesso di scriverti?",
+            "body": "Un ente può inviarti dei messaggi solo se ha una comunicazione specifica da recapitare a te, associata al tuo codice fiscale. Il tuo codice fiscale non viene comunicato dall'app IO all'ente, ma ciascun ente può utilizzare l'app IO per scriverti solo se ha già i tuoi dati (e quindi una relazione con te). \n \nSe non vuoi più ricevere comunicazioni da uno specifico ente, puoi disattivarne i servizi che non ti interessano: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nNella sezione 'Profilo > Preferenze > Gestione servizi' puoi decidere di lasciare accesa la comunicazione di tutti i servizi, oppure scegliere la configurazione manuale per cui dovrai configurare a uno a uno tutti i servizi dalla relativa schermata di dettaglio."
+          },
+          {
+            "title": "Vuoi contattare l'ente?",
+            "body": "Dai dettagli del messaggio puoi visualizzare le informazioni relative allo specifico servizio e ente erogatore. Se segui il link al profilo del servizio trovi le informazioni estese, e i recapiti attraverso i quali puoi contattare l'ente erogatore del servizio. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
+          }
+        ]
+      },
+      {
+        "route_name": "SERVICES_HOME",
+        "title": "Cosa puoi fare nei tuoi Servizi",
+        "content": "Qui puoi visualizzare la lista dei servizi nazionali o locali disponibili su IO. \nPremi sul nome di un servizio per visualizzarne i dettagli.",
+        "faqs": [
+          {
+            "title": "Come gestire i servizi su IO?",
+            "body": "Utilizza le configurazioni disponibili nella sezione 'Profilo > Preferenze > Gestione servizi', oppure le opzioni contenute nel dettaglio di ciascun servizio per decidere come riceverne le comunicazioni (messaggio in app, notifica push, inoltro del messaggio via e-mail). \n \nAttenzione! Vedere la lista completa dei servizi non significa che ti contatteranno servizi che non ti riguardano: gli enti comunicano con te solo se in possesso del tuo codice fiscale e nel momento in cui hanno necessità di inviarti comunicazioni importanti."
+          },
+          {
+            "title": "Puoi contattare gli enti tramite IO?",
+            "body": "Non puoi direttamente contattare gli enti dall'app IO ma puoi visualizzare le loro informazioni di contatto all'interno della sezione 'Servizi', nella scheda di ciascun servizio."
+          }
+        ]
+      },
+      {
+        "route_name": "SERVICE_DETAIL",
+        "title": "Dettagli del Servizio",
+        "content": "In questa schermata puoi visualizzare la descrizione del servizio, l'informativa privacy e condizioni d'uso, i dati di contatto dell'ente o del servizio e puoi configurare le modalità di comunicazione per questo specifico servizio. \n \nRicorda che su IO ti scriveranno solo servizi che hanno qualche informazione personalizzata da comunicarti: non riceverai messaggi di spam o contenuti che non ti riguardano direttamente. \n \nSe vuoi comunque impedire al servizio di contattarti puoi farlo nell'area 'Questo servizio può', disabilitando l'opzione 'Contattarti in app'. \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nDa questa pagina puoi inoltre gestire l'invio di notifiche push e l'inoltro dei messaggi anche al tuo indirizzo e-mail.",
+        "faqs": [
+          {
+            "title": "Cosa succede se disattivi un servizio?",
+            "body": "Non riceverai più le comunicazioni di quello specifico servizio nell'app IO. L'ente che eroga il servizio potrà comunque contattarti o essere contattato attraverso altri canali quali sito, email, numero di telefono o ufficio di pertinenza."
+          },
+          {
+            "title": "Come funzionano le notifiche push?",
+            "body": "Le notifiche push ti informano che è arrivato un nuovo messaggio nell'app IO, e ti invitano a procedere alla lettura. \n \nSe preferisci disattivarle, disabilita nell'area 'Questo servizio può' l'opzione 'Inviarti notifiche push'. Nella sezione Messaggi potrai comunque distinguere i messaggi non letti grazie al pallino blu."
+          },
+          {
+            "title": "Come funziona l'inoltro via email dei messaggi?",
+            "body": "Attivando l'inoltro via email dei messaggi, riceverai all'indirizzo email associato all'app una copia del messaggio che ricevi su IO. \nL'inoltro via mail non è disponibile per alcuni servizi, sulla base di decisioni prese dall'ente in merito alla sensibilità dei contenuti del messaggio stesso."
+          }
+        ]
+      },
+      {
+        "route_name": "PROFILE_PREFERENCES_EMAIL_FORWARDING",
+        "title": "Come gestire l'inoltro dei messaggi",
+        "content": "Qui puoi abilitare o disabilitare l'inoltro al tuo indirizzo e-mail dei messaggi che ricevi su IO."
+      },
+      {
+        "route_name": "PROFILE_PREFERENCES_SERVICES",
+        "title": "Gestisci servizi in app",
+        "content": "Qui puoi decidere come gestire la comunicazione dei servizi. \nL'app IO vuole essere un canale di comunicazione aggiuntivo per gli enti nazionali o locali che hanno qualcosa da dire proprio a te. \nNon manda messaggi broadcast o spam e per questo ti consigliamo di utilizzare la configurazione rapida, mantenendo la comunicazione dei servizi sempre attiva.",
+        "faqs": [
+          {
+            "title": "Perché dovrei usare la configurazione rapida?",
+            "body": "Perchè IO manda solo messaggi utili e rivolti proprio a te: gli enti erogatori dei servizi devono conoscere il tuo codice fiscale per poterti scrivere e questo è garanzia del fatto che hanno già una relazione con te. Usando la configurazione rapida non devi pensare a niente e riceverai i messaggi che ti riguardano anche dai servizi che arriveranno in futuro. \nSe decidi comunque di usare la configurazione manuale, sappi che gli enti potranno contattarti attraverso i canali tradizionali a loro disposizione."
+          },
+          {
+            "title": "Cosa succede se utilizzo la configurazione manuale?",
+            "body": "La configurazione manuale spegne la comunicazione di tutti i servizi, quelli attualmente presenti e quelli che arriveranno in futuro. \nPer ricevere i messaggi dai servizi che ti interessano dovrai configurarli uno a uno dalle relative schede servizio. \nAttenzione! Spegnendo la comunicazione tramite IO, l'ente che eroga il servizio potrà comunque contattarti attraverso i canali tradizionali disponibili (es. e-mail, posta, SMS)."
+          }
+        ]
+      },
+      {
+        "route_name": "EUCOVIDCERT_CERTIFICATE",
+        "title": "La tua Certificazione Verde COVID-19",
+        "content": "Questo è il messaggio contenente il codice QR e tutte le informazioni relative alla tua Certificazione Verde COVID-19, il documento che attesta un vaccino, l'esito di un tampone o l'avvenuta guarigione da COVID-19 e che permette di circolare in sicurezza in Italia e in Europa",
+        "faqs": [
+          {
+            "title": "Posso ricevere su IO più di un certificato verde?",
+            "body": "Sì, ad esempio perchè hai effettuato diversi tamponi, o perchè hai un certificato di guarigione e hai comunque fatto il vaccino."
+          },
+          {
+            "title": "Come faccio a vedere il certificato se non ho disponibile la connessione ad Internet?",
+            "body": "IO chiede il QR code dei certificati alla Piattaforma Nazionale DGC ogni volta che apri il relativo messaggio, quindi in quel momento devi essere connesso. Una volta ottenuto il certificato, puoi però salvare il relativo QR code nella galleria immagini del tuo dispositivo con l'apposito pulsante, così da poterlo mostrare all'occorrenza anche in assenza di connessione."
+          },
+          {
+            "title": "Come faccio a distinguere fra due certificati, ad esempio vaccinazione o un tampone, se vedo solo il QR Code?",
+            "body": "Quando esibirai il tuo Certificato Verde, chi lo verificherà non dovrà conoscere i tuoi dati sanitari ma solo essere sicuro che sia valido: per questo nessun dato sanitario è visibile nella schemata dove trovi il QR code. Per leggere i dati sanitari relativi al certificato premi il pulsante 'Dettagli'."
+          },
+          {
+            "title": "Posso ricevere su IO i certificati dei miei familiari?",
+            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Il certificato digitale che trovo su IO sostituisce quello cartaceo?",
+            "body": "La Certificazione verde COVID-19, emessa dalla piattaforma nazionale del Ministero della Salute, è in formato digitale. Su alcuni canali alternativi all'app IO è anche disponibile in versione PDF stampabile per chi desideri averne una copia cartacea. \n In ogni caso, entrambi i formati contengono le stesse informazioni che identificano il tuo certificato (un QR Code e un sigillo elettronico qualificato). Per maggiori dettagli sugli altri canali: [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Perché non vedo più il mio certificato verde su IO?",
+            "body": "I certificati su IO non scompaiono, restano sempre a disposizione nell'elenco dei messaggi. Quando provi a visualizzare un certificato, questo viene scaricato in tempo reale dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute. In alcuni casi (certificati scaduti o annullati) potresti non vedere più il QR code e le informazioni di dettaglio. Potrai comunque contattare l'assistenza dedicata per avere maggiori informazioni."
+          },
+          {
+            "title": "Cosa succede se, dopo aver ricevuto il certificato, disattivo IO?",
+            "body": "Se hai salvato il certificato come immagine sul tuo dispositivo, continuerà ad essere disponibile. Altrimenti potrai scaricarlo nuovamente attraverso gli altri canali disponibili. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Perchè il mio certificato ora risulta non più valido?",
+            "body": "La durata della validità dei certificati è definita nella piattaforma nazionale del Ministero della Salute, che è responsabile del rilascio dei certificati. Consulta le FAQ dedicate sul sito [dgc.gov.it](https://www.dgc.gov.it/web/faq.html) per maggiori informazioni."
+          },
+          {
+            "title": "Fino a quando è valido il mio certificato su IO?",
+            "body": "Il certificato Verde su IO ha la stessa validità dei certificati ottenibili presso gli altri canali. La decisione sulla durata della validità dei certificati è indipendente da IO e spetta alle autorità competenti. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/) ed eventualmente il sito del Ministero della Salute [https://www.salute.gov.it](https://www.salute.gov.it) per maggiori informazioni."
+          },
+          {
+            "title": "Dove posso salvare il certificato sull'app IO?",
+            "body": "Premendo il pulsante 'Salva', puoi salvare il QR code del certificato nella galleria immagini del tuo dispositivo per poterlo usare anche se non sei connesso ad internet."
+          },
+          {
+            "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
+            "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
+          },
+          {
+            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          }
+        ]
+      },
+      {
+        "route_name": "EUCOVIDCERT_MARKDOWN_DETAILS",
+        "title": "I dettagli della tua Certificazione Verde COVID-19",
+        "content": "Qui trovi tutte le informazioni relative alla tua Certificazione Verde COVID-19.",
+        "faqs": [
+          {
+            "title": "Posso ricevere su IO più di un certificato verde?",
+            "body": "Sì, ad esempio perchè hai effettuato diversi tamponi, o perchè hai un certificato di guarigione e hai comunque fatto il vaccino."
+          },
+          {
+            "title": "Posso ricevere su IO i certificati dei miei familiari?",
+            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Il certificato digitale che trovo su IO sostituisce quello cartaceo?",
+            "body": "Sì, il certificato digitale e quello cartaceo contengono le stesse informazioni."
+          },
+          {
+            "title": "Cosa succede se, dopo aver ricevuto il certificato, disattivo IO?",
+            "body": "Se hai salvato il certificato come immagine sul tuo dispositivo, continuerà ad essere disponibile. Altrimenti potrai scaricarlo nuovamente attraverso gli altri canali disponibili. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Fino a quando è valido il mio certificato su IO?",
+            "body": "Il certificato Verde su IO ha la stessa validità dei certificati ottenibili presso gli altri canali. La decisione sulla durata della validità dei certificati è indipendente da IO e spetta alle autorità competenti. Consulta il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/) ed eventualmente il sito del Ministero della Salute [https://www.salute.gov.it](https://www.salute.gov.it) per maggiori informazioni."
+          },
+          {
+            "title": "Dove posso salvare il certificato sull'app IO?",
+            "body": "Premendo il pulsante 'Salva', puoi salvare il QR code del certificato nella galleria immagini del tuo dispositivo per poterlo usare anche se non sei connesso ad internet."
+          },
+          {
+            "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
+            "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
+          },
+          {
+            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          }
+        ]
+      },
+      {
+        "route_name": "CGN_INFORMATION_TOS",
+        "title": "Attiva la Carta Giovani Nazionale",
+        "content": "Qui puoi visualizzare tutte le informazioni relative alla Carta Giovani Nazionale, il provvedimento istituito dal Dipartimento per le Politiche Giovanili e il Servizio Civile Universale che dà diritto a sconti e agevolazioni ai giovani residenti in Italia sull'acquisto di determinati beni e servizi.",
+        "faqs": [
+          {
+            "title": "Come faccio a richiedere la Carta Giovani Nazionale?",
+            "body": "Se sei maggiorenne e risiedi in Italia, premi sul pulsante 'Richiedi la Carta' in fondo alla pagina e segui le indicazioni in app. L'app IO effettuerà un controllo sulla tua età e, se risulterà idonea, attiverà la Carta Giovani Nazionale."
+          },
+          {
+            "title": "Cos'è il circuito EYCA?",
+            "body": "Il circuito EYCA unisce tutte le carte giovani dei Paesi europei e offre agevolazioni in ottica di reciprocità: un giovane italiano con Carta Giovani Nazionale aderente a EYCA può usufruire dei benefici previsti nei Paesi aderenti, così come i giovani stranieri in visita nel nostro Paese, potranno utilizzare le loro carte EYCA presso gli esercenti aderenti a Carta Giovani Nazionale."
+          },
+          {
+            "title": "Cosa devo fare per aderire a EYCA?",
+            "body": "L'adesione a EYCA è prevista solo per i giovani fino ai 30 anni compiuti. Se rientri in questa fascia d'età non dovrai fare nulla: sarà IO a comunicare la richiesta ai sistemi di EYCA. Nel dettaglio della tua Carta Giovani Nazionale compariranno il numero di carta e il logo EYCA. Questi dati ti serviranno per accedere alle agevolazioni previste nel circuito europeo."
+          },
+          {
+            "title": "Quanto tempo passa dal momento della richiesta al momento dell’attivazione della mia Carta Giovani Nazionale?",
+            "body": "Se possiedi tutti i requisiti che danno diritto alla Carta Giovani Nazionale, l’attivazione è pressoché immediata: in pochi minuti, dal momento della richiesta, IO completa le verifiche necessarie e attiva la tua Carta."
+          },
+          {
+            "title": "Posso condividere le agevolazioni della Carta Giovani Nazionale con i miei familiari e amici?",
+            "body": "No, le agevolazioni promosse dalla Carta Giovani Nazionale hanno carattere individuale e nominativo, e possono quindi essere utilizzate esclusivamente dal titolare della Carta. L’uso improprio della carta può comportare la sua revoca."
+          },
+          {
+            "title": "Devo aggiungere una carta di credito sull’app IO per richiedere e utilizzare la Carta Giovani Nazionale?",
+            "body": "No, il suo utilizzo non è associato in alcun modo alla disponibilità di una carta di credito né di altri metodi di pagamento salvati nell’app. Quando utilizzerai le agevolazioni della Carta per ottenere uno sconto - sull’e-commerce o presso le strutture fisiche dell’operatore convenzionato - provvederai al pagamento con la modalità che preferisci."
+          },
+          {
+            "title": "Se utilizzo le agevolazioni della mia Carta Giovani Nazionale per un acquisto online, l’applicazione dello sconto è immediata o riceverò un rimborso successivamente?",
+            "body": "L’applicazione dello sconto è immediata. Nel caso in cui l’agevolazione preveda l’inserimento di un codice sconto in fase di acquisto, assicurati di digitarlo  correttamente, per vedere subito applicato lo sconto al carrello dell’e-commerce dell’operatore."
+          }
+        ]
+      },
+      {
+        "route_name": "CGN_DETAILS",
+        "title": "La tua Carta Giovani Nazionale",
+        "content": "Questa è la schermata di dettaglio della tua Carta Giovani Nazionale. Da qui puoi visualizzare la lista degli esercenti e delle istituzioni che aderiscono all'iniziativa e le relative agevolazioni, o copiare il tuo numero di carta EYCA se hai tra i 18 e i 30 anni.",
+        "faqs": [
+          {
+            "title": "Come posso ottenere sconti con la Carta Giovani Nazionale?",
+            "body": "Per acquisti presso strutture fisiche, apri l'app IO e mostra la Carta Giovani Nazionale prima del pagamento. Per gli acquisti online, copia il codice sconto che trovi nella scheda dell'agevolazione di tuo interesse e incollalo nel campo sconto presente nel portale dell'esercente. Se il codice inserito è corretto, lo sconto verrà automaticamente applicato al tuo carrello."
+          },
+          {
+            "title": "Cos'è il circuito EYCA?",
+            "body": "Il circuito EYCA unisce tutte le carte giovani dei Paesi europei e offre agevolazioni in ottica di reciprocità: un giovane italiano con Carta Giovani Nazionale aderente a EYCA può usufruire dei benefici previsti nei Paesi aderenti, così come i giovani stranieri in visita nel nostro Paese, potranno utilizzare le loro carte EYCA presso gli esercenti aderenti a Carta Giovani Nazionale."
+          },
+          {
+            "title": "Cosa devo fare per aderire a EYCA?",
+            "body": "L'adesione a EYCA è prevista solo per i giovani fino ai 30 anni compiuti. Se rientri in questa fascia d'età non dovrai fare nulla: sarà IO a comunicare la richiesta ai sistemi di EYCA. Nel dettaglio della tua Carta Giovani Nazionale compariranno il numero di carta e il logo EYCA. Questi dati ti serviranno per accedere alle agevolazioni previste nel circuito europeo."
+          },
+          {
+            "title": "Quando scade la mia Carta Giovani Nazionale?",
+            "body": "La tua Carta Giovani Nazionale perde validità al compimento del 36esimo anno di età. La data di scadenza è indicata nel dettaglio della tua Carta sempre consultabile nella sezione “Portafoglio” dell’App. Dopo i 30 anni, in ogni caso, puoi usufruire soltanto delle agevolazioni promosse sul territorio nazionale, dal momento che quelle offerte dal circuito EYCA a livello europeo sono valide fino al compimento del 31° anno di età."
+          },
+          {
+            "title": "Posso disattivare la mia Carta Giovani Nazionale?",
+            "body": "Sì. Dalla schermata di dettaglio della CGN premi “Disattiva la tua carta” e conferma. Da quel momento non vedrai più la CGN nel portafoglio. Disattivando la CGN, perdi anche i diritti relativi al circuito EYCA."
+          },
+          {
+            "title": "Posso condividere le agevolazioni della Carta Giovani Nazionale con i miei familiari e amici?",
+            "body": "No, le agevolazioni promosse dalla Carta Giovani Nazionale hanno carattere individuale e nominativo, e possono quindi essere utilizzate esclusivamente dal titolare della Carta. L’uso improprio della carta può comportare la sua revoca."
+          },
+          {
+            "title": "Se utilizzo le agevolazioni della mia Carta Giovani Nazionale per un acquisto online, l’applicazione dello sconto è immediata o riceverò un rimborso successivamente?",
+            "body": "L’applicazione dello sconto è immediata. Nel caso in cui l’agevolazione preveda l’inserimento di un codice sconto in fase di acquisto, assicurati di digitarlo  correttamente, per vedere subito applicato lo sconto al carrello dell’e-commerce dell’operatore."
+          },
+          {
+            "title": "Quanti acquisti, online o fisici, posso effettuare usufruendo delle agevolazioni della Carta Giovani Nazionale?",
+            "body": "L’iniziativa non prevede un limite al numero degli sconti utilizzabili. In ogni caso, ogni operatore convenzionato può disporre autonomamente delle modalità di utilizzo dei codici sconto che mette a disposizione rendendo esplicite eventuali condizioni nella scheda relativa alle proprie agevolazioni, sempre visibile nell’App IO. "
+          }
+        ]
+      },
+      {
+        "route_name": "CGN_MERCHANTS_LIST",
+        "title": "Lista operatori",
+        "content": "Qui puoi visualizzare la lista sempre aggiornata degli esercenti e delle istituzioni che aderiscono all'iniziativa. La lista contiene sia strutture fisiche che operatori online.",
+        "faqs": [
+          {
+            "title": "Come posso ottenere sconti con la Carta Giovani Nazionale?",
+            "body": "Per acquisti presso strutture fisiche, apri l'app IO e mostra la Carta Giovani Nazionale prima del pagamento. Per gli acquisti online, copia il codice sconto che trovi nella scheda dell'agevolazione di tuo interesse e incollalo nel campo sconto presente nel portale dell'esercente. Se il codice inserito è corretto, lo sconto verrà automaticamente applicato al tuo carrello."
+          },
+          {
+            "title": "Perché il codice sconto non funziona?",
+            "body": "Se il codice non risulta valido: \n\n - verifica di averlo inserito correttamente; \n\n - Assicurati che sia ancora valido: alcuni codici scadono nel giro di poco tempo; \n\n - Controlla nel dettaglio dell'agevolazione se l'operatore applica condizioni relative alle modalità di utilizzo e alla validità dello sconto. \n\n Se il problema persiste o il tuo caso non rientra in quelli descritti, inviaci una richiesta di assistenza."
+          }
+        ]
+      },
+      {
+        "route_name": "CGN_MERCHANTS_DETAIL",
+        "title": "Dettaglio operatore",
+        "content": "In questa schermata trovi tutte le informazioni relative all'operatore che hai selezionato, incluse le agevolazioni in corso di validità.",
+        "faqs": [
+          {
+            "title": "Come posso ottenere sconti con la Carta Giovani Nazionale?",
+            "body": "Per acquisti presso strutture fisiche, apri l'app IO e mostra la Carta Giovani Nazionale prima del pagamento. Per gli acquisti online, copia il codice sconto che trovi nella scheda dell'agevolazione di tuo interesse e incollalo nel campo sconto presente nel portale dell'esercente. Se il codice inserito è corretto, lo sconto verrà automaticamente applicato al tuo carrello."
+          },
+          {
+            "title": "Perché il codice sconto non funziona?",
+            "body": "Se il codice non risulta valido: \n\n - verifica di averlo inserito correttamente; \n\n - Assicurati che sia ancora valido: alcuni codici scadono nel giro di poco tempo; \n\n - Controlla nel dettaglio dell'agevolazione se l'operatore applica condizioni relative alle modalità di utilizzo e alla validità dello sconto. \n\n Se il problema persiste o il tuo caso non rientra in quelli descritti, inviaci una richiesta di assistenza."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_INFORMATION_TOS",
+        "title": "Programma Cashback",
+        "content": "Qui sono visualizzate tutte le informazioni relative al Cashback, il provvedimento istituito dal Ministero dell'Economia e delle Finanze per incentivare l'utilizzo della moneta elettronica anche per piccole somme.",
+        "faqs": [
+          {
+            "title": "Come faccio a richiedere il Cashback?",
+            "body": "Se sei maggiorenne e risiedi in Italia, semplicemente premi sul pulsante 'Attiva il Cashback' in fondo alla pagina e segui il flusso che ti viene proposto.\nA seguito dell'autodichiarazione, ti verrà chiesto di:\n- inserire un IBAN, che utilizzeremo a fine periodo per rimborsarti eventuali importi accumulati;\n- aggiungere metodi di pagamento elettronici (o attivare quelli già presenti nel tuo portafoglio).\n\nEntrambi i passaggi sono facoltativi, ma ti consigliamo di effettuarli subito per evitare di dimenticarti e iniziare quanto prima ad accumulare transazioni valide."
+          },
+          {
+            "title": "Cosa serve per richiedere il Cashback?",
+            "body": "Devi essere maggiorenne, risiedere in Italia e avere almeno un IBAN a te intestato o cointestato e almeno un metodo di pagamento elettronico."
+          },
+          {
+            "title": "Ci sono limiti di reddito? Serve presentare una DSU per il calcolo dell’ISEE per accedere al Cashback?",
+            "body": "No, l’erogazione dei rimborsi previsti dal programma non è legata in alcun modo al reddito né alla situazione patrimoniale dei partecipanti."
+          },
+          {
+            "title": "Possono partecipare tutti i componenti maggiorenni dello stesso nucleo familiare?",
+            "body": "Per aderire al Cashback non c’è un limite al numero di partecipanti per nucleo familiare. Ogni componente maggiorenne e residente in Italia può iscriversi individualmente al programma e ricevere il proprio rimborso."
+          },
+          {
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_DECLARATION",
+        "title": "Iscrizione al Cashback",
+        "content": "Leggi le condizioni descritte in questa pagina e, se corrispondono al vero, spunta i relativi quadratini, premendoli.\nPuoi proseguire nell'attivazione del Cashback solo se tutti e 4 i quadratini sono spuntati.\nTi ricordiamo che dichiarando il falso potrai incorrere in sanzioni penali, oltre a perdere il diritto al rimborso di eventuali importi accumulati ai sensi degli [Articoli 46 e 47 del Dpr 28 dicembre 2000 n. 445](https://www.normattiva.it/uri-res/N2Ls?urn:nir:stato:decreto.del.presidente.della.repubblica:2000-12-28;445)",
+        "faqs": [
+          {
+            "title": "Cosa vuole dire \"acquisti non legati ad attività di Impresa, Arte o Professione\"?",
+            "body": "Significa che non sono valide le transazioni per acquisti legati alla propria attività professionale, ad esempio per l'acquisto di materiale per l'ufficio. I cittadini devono attivare al Cashback solo i metodi di pagamento con cui effettuano acquisti di carattere esclusivamente personale."
+          },
+          {
+            "title": "Per aderire devo avere la cittadinanza italiana?",
+            "body": "No, è sufficiente che tu abbia la residenza in Italia."
+          },
+          {
+            "title": "Mio/a figlio/a è minorenne, ma ha una carta; può partecipare all’iniziativa?",
+            "body": "No, un minorenne non può partecipare al Cashback. Solo se sei il o la titolare della carta di tuo/a figlio/a, puoi registrarla tra i metodi di pagamento elettronici e attivarla sul tuo profilo ai fini del Cashback."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_ENROLL_PAYMENT_METHODS",
+        "title": "Abilita i tuoi metodi di pagamento al Cashback",
+        "content": "In questa schermata ti mostriamo i metodi di pagamento che hai già registrato nel tuo Portafoglio in IO.\nSeleziona quelli che vuoi attivare per il Cashback – premendo sull'icona grigia alla destra dell'elemento nella lista – e conferma la tua scelta.\nTi ricordiamo che puoi attivare ai fini del Cashback solo i metodi di pagamento **a te intestati.**",
+        "faqs": [
+          {
+            "title": "Cosa vuol dire 'Metodi di pagamento non attivabili o non compatibili'?",
+            "body": "Se nella lista vedi metodi di pagamento sotto questa dicitura, significa che alcuni metodi che hai salvato non possono essere attivati ai fini del Cashback. Puoi toccare la 'i' a fianco di ciascun elemento per leggere la motivazione."
+          },
+          {
+            "title": "Quali metodi di pagamento posso usare per il Cashback?",
+            "body": "Ti invitiamo a controllare la lista completa al seguente link: [Metodi di Pagamento](https://io.italia.it/metodi-pagamento).\nStiamo lavorando per includere quanti più metodi di pagamento elettronico possibile, per cui la lista si potrebbe presto aggiornare!"
+          },
+          {
+            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+          },
+          {
+            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+          },
+          {
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_NO_PAYMENT_METHODS",
+        "title": "Salva i tuoi metodi di pagamento e abilitali al Cashback",
+        "content": "Per iniziare a collezionare transazioni valide che ti permettano di accumulare il cashback, è necessario salvare in IO i tuoi metodi di pagamento elettronico e abilitarli al Cashback.\nPuoi farlo anche in un secondo momento, ma ti informiamo che inizieremo a collezionare le transazioni su un determinato metodo a partire dalle 00:01 del giorno successivo alla sua attivazione in IO.\nTi ricordiamo che puoi attivare ai fini del Cashback solo i metodi di pagamento **a te intestati**.",
+        "faqs": [
+          {
+            "title": "Quali metodi di pagamento posso usare per il Cashback?",
+            "body": "Ti invitiamo a controllare la lista completa al seguente link: [Metodi di Pagamento](https://io.italia.it/metodi-pagamento).\nStiamo lavorando per includere quanti più metodi di pagamento elettronico possibile, per cui la lista si potrebbe presto aggiornare!"
+          },
+          {
+            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)."
+          },
+          {
+            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)."
+          },
+          {
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_IBAN",
+        "title": "Inserisci il tuo IBAN",
+        "content": "In questa schermata puoi inserire l'IBAN di un conto o di una carta dotata di IBAN su cui vuoi ricevere gli eventuali rimborsi a periodo concluso. Il conto o la carta in questione **devono essere intestate o cointestate a te.**\nQuesto passaggio non è obbligatorio, ma ti raccomandiamo di farlo entro la fine del periodo per evitare eventuali problemi con i rimborsi.",
+        "faqs": [
+          {
+            "title": "Posso cambiare l’IBAN con cui ho aderito al Cashback?",
+            "body": "Sì, puoi modificare l’IBAN in ogni momento fino alla scadenza di ciascun periodo."
+          },
+          {
+            "title": "Due partecipanti al Cashback possono indicare per i rimborsi lo stesso codice IBAN, se sono co-intestatari?",
+            "body": "Sì, dal momento che quel codice IBAN risulta associato ai Codici Fiscali di entrambi partecipanti, iscritti individualmente al programma."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_DETAILS",
+        "title": "Cashback",
+        "content": "Qui sono visualizzati i dettagli del Cashback e le azioni necessarie per gestire i tuoi metodi di pagamento associati e l'IBAN per ricevere l'eventuale rimborso. Se vuoi vedere tutte le informazioni relative al programma, visita il sito [io.italia.it/cashback](https://io.italia.it/cashback)",
+        "faqs": [
+          {
+            "title": "Perché vedo il cashback a cui ho diritto espresso in migliaia?",
+            "body": "In alcuni dispositivi il messaggio sul cashback a cui hai diritto riporta la cifra in un formato errato: verrà corretto a partire dalla prossima versione dell'app. Il valore corretto è quello riportato nella card del Cashback: ti ricordiamo che in ciascun periodo puoi accumulare al massimo € 150,00 di rimborso."
+          },
+          {
+            "title": "Come devo leggere questa schermata?",
+            "body": "Nella card in alto è riportato il periodo relativo al Cashback e se si tratta di un periodo attivo, o concluso. Inoltre l'importo descrive la cifra di Cashback accumulato fino a questo momento. Se vicino all'importo c'è un lucchetto, significa che ancora non si è raggiunto il numero minimo di transazioni richieste.\n\nAppena sotto le statistiche descrivono lo stato e l'andamento nell'iniziativa, ad esempio il numero di transazioni accumulate ed eventualmente la posizione in classifica per ottenere il Super Cashback."
+          },
+          {
+            "title": "Cosa posso fare in questa schermata?",
+            "body": "Il modulo relativo ai metodi permette di attivare/disattivare o aggiungere nuovi metodi di pagamento, così come il modulo dell'IBAN permette di inserire o modificare l'IBAN già inserito.\n\nInfine i due pulsanti in basso permettono di visualizzare il dettaglio di tutte le transazioni valide registrate o disiscriversi dal Cashback."
+          },
+          {
+            "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
+            "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n- carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (_esclusi, quindi, quelli solo per accumulo punti_);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (**sull'App IO a partire dal 2021**).\n\n**Nota bene**: All’avvio del Programma, alcune carte o app di pagamento che utilizzi potrebbero NON essere registrabili da subito, seppur inclusi nelle categorie di cui sopra, o potrebbero essere registrabili solo da un [canale alternativo a IO](https://io.italia.it/cashback/issuer/). Questo potrebbe dipendere dai tempi tecnici necessari per rendere operativi i metodi di pagamento elettronici nell’ambito del Cashback. [Verifica quali metodi di pagamento puoi già attivare per il Cashback](https://io.italia.it/metodi-pagamento/)."
+          },
+          {
+            "title": "Quali acquisti sono validi ai fini del Cashback?",
+            "body": "In generale, sono validi gli acquisti effettuati sul territorio nazionale, con i metodi di pagamento elettronico attivati al Cashback, tramite dispositivi fisici di accettazione, come i POS, forniti da [Acquirer Convenzionati che ti permettano di partecipare all’iniziativa](https://io.italia.it/cashback/acquirer). Per questo, prima di eseguire un pagamento verifica sempre con l’esercente se il suo sistema di incasso consente la partecipazione al Cashback. Gli acquisti effettuati con una carta PagoBANCOMAT risulteranno sempre validi a prescindere dal dispositivo di accettazione."
+          },
+          {
+            "title": "Quando vengono aggiunte transazioni alla lista?",
+            "body": "Possono passare in media 3 giorni lavorativi. Non vedi ancora la transazione?\n- Controlla se la tua banca ha già contabilizzato la transazione: i dati vengono trasmessi all’app entro 5 giorni lavorativi dalla contabilizzazione.\n- La transazione potrebbe essere stata gestita con il POS di un soggetto (acquirer) [non ancora convenzionato](https://io.italia.it/cashback/acquirer).\n\nRicorda! Quando si aggiunge un nuovo metodo di pagamento, verranno collezionate le transazioni effettuate a partire dalle 00:01 del giorno successivo a quello dell'attivazione."
+          },
+          {
+            "title": "Perché vedo carte che non riconosco nella sezione 'Attivati su altri canali'?",
+            "body": "In questa sezione trovi tutti i metodi di pagamento elettronici attivati tramite i canali messi a disposizione dei cosiddetti [Issuer Convenzionati](https://io.italia.it/cashback/issuer).\nAlcuni operatori consentono anche l’aggiunta delle rispettive carte abilitate attraverso i cosiddetti 'wallet' come **Apple Pay, Google Pay o Samsung Pay**.\n\n**In questo periodo sperimentale**, detto 'Extra Cashback di Natale', potresti vedere perciò dei numeri di carta differenti rispetto a quello che vedi sulla carta fisica.\n\nTi assicuriamo che non c’è nessun errore o problema di privacy: **si tratta delle versioni virtuali associate alla tua carta**, composte da codici casuali (detti in gergo tecnico 'token'), utilizzati per mettere in sicurezza i pagamenti che effettui tramite smartphone.\n\nPer questo motivo, ad ogni transazione effettuata con il tuo smartphone, non viene mostrato all’esercente il numero della carta fisica, ma si ricorre a questo tipo di versione 'cifrata' (detta anche 'tokenizzata').\n\nStiamo lavorando con i soggetti del settore dei pagamenti coinvolti nell’iniziativa per migliorare la visualizzazione sull’app IO di questo tipo di carte.\n\nPer maggiori informazioni puoi rivolgerti all’[Issuer Convenzionato](https://io.italia.it/cashback/issuer) con cui hai attivato la tua carta per il Cashback."
+          },
+          {
+            "title": "Posso cambiare l’IBAN con cui ho aderito al Cashback?",
+            "body": "Sì, puoi modificare l’IBAN in ogni momento fino alla scadenza di ciascun periodo."
+          },
+          {
+            "title": "Sono validi anche gli acquisti effettuati con una carta aziendale?",
+            "body": "No, solo quelli a carattere privato. Le spese che rispondono a esigenze lavorative, professionali o aziendali non sono valide ai fini del Cashback."
+          },
+          {
+            "title": "Qual è l'importo massimo del Cashback che posso ottenere?",
+            "body": "Il rimborso è pari al 10% dell’importo di ogni transazione valida ai fini del programma, effettuata durante uno dei periodi previsti. L’importo considerato per singola transazione è di massimo 150 euro, mentre non è previsto un importo minimo.\nIl rimborso massimo che puoi ottenere in ciascun periodo è pari a 150 euro. Ad esempio, se hai effettuato:\n- una spesa di 20 euro, l’importo ottenuto per il Cashback sarà di 2 euro;\n- una spesa di 150 euro, l’importo accumulato sarà di 15 euro;\n- una spesa superiore a 150 euro, ad esempio di 700 euro, accumulerai comunque 15 euro di Cashback.\nNell’app IO è sempre possibile visualizzare l’importo del Cashback accumulato fino a quel momento e il dettaglio delle singole transazioni che lo hanno generato. Come già scritto, l’importo massimo che puoi ottenere per singolo periodo è di 150 euro, per cui una volta raggiunto questo limite, eventuali nuove transazioni non genereranno ulteriori rimborsi."
+          },
+          {
+            "title": "Quando riceverò il rimborso ottenuto sul mio conto corrente?",
+            "body": "I rimborsi sono erogati entro 60 giorni dal termine del periodo, con un bonifico sull’IBAN che hai comunicato."
+          },
+          {
+            "title": "Se sono iscritto al Cashback in un certo periodo, resterò iscritto anche per il periodo successivo?",
+            "body": "Sì, considera, però, che al termine di ciascun periodo si conclude il calcolo delle transazioni che ti consentono di ottenere i relativi rimborsi e si riparte da zero all’avvio del periodo successivo. In ogni momento hai la possibilità di attivare o disattivare i tuoi metodi di pagamento o di cancellarti dal programma."
+          },
+          {
+            "title": "Cosa succede se mi cancello dal programma?",
+            "body": "La cancellazione dal programma comporta la perdita del diritto ai rimborsi per il periodo in corso. Se non vuoi perdere i rimborsi accumulati, devi aspettare che ti vengano accreditati sull’IBAN che hai comunicato (solitamente entro 60 giorni successivi alla fine di ciascun periodo)."
+          }
+        ]
+      },
+      {
+        "route_name": "BPD_TRANSACTIONS",
+        "title": "Le tue transazioni valide ai fini del Cashback",
+        "content": "In questa pagina sono visualizzate tutte le transazioni che ti hanno permesso di accumulare dei rimborsi, o di acquisire posizioni nella classifica del Super Cashback (a partire da gennaio 2021).\n\nPremendo su una transazione si apre un dettaglio con maggiori informazioni.\n\nI dati relativi alle transazioni non contengono informazioni circa il tipo di esercente presso cui è avvenuta.",
+        "faqs": [
+          {
+            "title": "Quali acquisti sono validi ai fini del Cashback?",
+            "body": "In generale, sono validi gli acquisti effettuati sul territorio nazionale, con i metodi di pagamento elettronico attivati al Cashback, tramite dispositivi fisici di accettazione, come i POS, forniti da [Acquirer Convenzionati che ti permettano di partecipare all’iniziativa](https://io.italia.it/cashback/acquirer). Per questo, prima di eseguire un pagamento verifica sempre con l’esercente se il suo sistema di incasso consente la partecipazione al Cashback. Gli acquisti effettuati con una carta PagoBANCOMAT risulteranno sempre validi a prescindere dal dispositivo di accettazione."
+          },
+          {
+            "title": "Quando vengono aggiunte transazioni alla lista?",
+            "body": "Possono passare in media 3 giorni lavorativi. Non vedi ancora la transazione?\n- Controlla se la tua banca ha già contabilizzato la transazione: i dati vengono trasmessi all’app entro 5 giorni lavorativi dalla contabilizzazione.\n- La transazione potrebbe essere stata gestita con il POS di un soggetto (acquirer) [non ancora convenzionato](https://io.italia.it/cashback/acquirer).\n\nRicorda! Quando si aggiunge un nuovo metodo di pagamento, verranno collezionate le transazioni effettuate a partire dalle 00:01 del giorno successivo a quello dell'attivazione."
+          },
+          {
+            "title": "Perché vedo carte che non riconosco nella lista delle transazioni?",
+            "body": "Alcuni operatori consentono anche l’aggiunta delle rispettive carte abilitate attraverso i cosiddetti 'wallet' come **Apple Pay, Google Pay o Samsung Pay**.\n\n**In questo periodo sperimentale**, detto 'Extra Cashback di Natale', potresti vedere perciò dei numeri di carta differenti rispetto a quello che vedi sulla carta fisica.\n\nTi assicuriamo che non c’è nessun errore o problema di privacy: **si tratta delle versioni virtuali associate alla tua carta**, composte da codici casuali (detti in gergo tecnico 'token'), utilizzati per mettere in sicurezza i pagamenti che effettui tramite smartphone.\n\nPer questo motivo, ad ogni transazione effettuata con il tuo smartphone, non viene mostrato all’esercente il numero della carta fisica, ma si ricorre a questo tipo di versione 'cifrata' (detta anche 'tokenizzata').\n\nStiamo lavorando con i soggetti del settore dei pagamenti coinvolti nell’iniziativa per migliorare la visualizzazione sull’app IO di questo tipo di carte.\n\nPer maggiori informazioni puoi rivolgerti all’[Issuer Convenzionato](https://io.italia.it/cashback/issuer) con cui hai attivato la tua carta per il Cashback."
+          },
+          {
+            "title": "Perché vedo una transazione con €0 di cashback?",
+            "body": "Se alcune transazioni della lista mostrano €0 come cashback accumulato, significa che probabilmente hai già raggiunto il massimo importo di Cashback ottenibile. Tutte le transazioni collezionate dopo aver raggiunto il traguardo, frutteranno €0, ma contribuiranno alla tua posizione per ottenere il Super Cashback, se attivo nel periodo corrente."
+          },
+          {
+            "title": "C’è un importo minimo sugli acquisti per far sì che le transazioni vengano conteggiate?",
+            "body": "No, per le transazioni **non è previsto un importo minimo**. Ma, nel caso del rimborso percentuale (Cashback 10%), l’importo massimo ottenibile per singola transazione è 15 euro, anche se la transazione supera i 150 euro."
+          },
+          {
+            "title": "C’è un numero massimo di acquisti (nell’arco di una giornata o per la durata di un periodo del programma), oltre il quale le transazioni non sono più conteggiate per il Cashback?",
+            "body": "No, non c’è un numero massimo di acquisti. Esiste però un importo massimo dei rimborsi che puoi ottenere, ovvero 150 euro per ciascun periodo. Una volta raggiunto l’importo massimo, le nuove transazioni concorreranno alla tua posizione nella classifica del Super Cashback (da gennaio 2021). [Consulta la Guida per saperne di più](https://io.italia.it/cashback/guida)"
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_SEARCH_AVAILABLE_USER_BANCOMAT",
+        "title": "Le tue carte PagoBANCOMAT",
+        "content": "In questa schermata ti mostriamo la o le carte PagoBANCOMAT a te intestate. Puoi aggiungerle premendo 'Aggiungi', oppure saltare la carta in questione per uscire dal flusso o passare alla carta successiva nel caso ne siano state trovate più di una.",
+        "faqs": [
+          {
+            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
+        "title": "Vuoi iscriverti al programma Cashback?",
+        "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
+        "faqs": [
+          {
+            "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
+            "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
+          },
+          {
+            "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
+            "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
+        "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
+        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+        "faqs": [
+          {
+            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+          },
+          {
+            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+          },
+          {
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+          },
+          {
+            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
+        "title": "Attiva il Cashback sulle tue carte",
+        "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+        "faqs": [
+          {
+            "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+            "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+          },
+          {
+            "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+            "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+          },
+          {
+            "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+            "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+          },
+          {
+            "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+            "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
+        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+        "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
+        "faqs": [
+          {
+            "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
+            "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
+          },
+          {
+            "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
+            "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
+          },
+          {
+            "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+            "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_START",
+        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+        "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
+        "faqs": [
+          {
+            "title": "Posso aggiungere anche carte con circuito internazionale?",
+            "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
+          },
+          {
+            "title": "Perché non trovo alcuna carta?",
+            "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
+        "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+        "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
+        "faqs": [
+          {
+            "title": "Perché la data di scadenza è diversa?",
+            "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+          },
+          {
+            "title": "Perché il numero della carta è diverso?",
+            "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+          },
+          {
+            "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+            "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_COBADGE_DETAIL",
+        "title": "La tua carta con circuito internazionale",
+        "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
+        "faqs": [
+          {
+            "title": "Cosa posso fare da qui?",
+            "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
+          },
+          {
+            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+            "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+          },
+          {
+            "title": "Perché la data di scadenza è diversa?",
+            "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+          },
+          {
+            "title": "Perché il numero della carta è diverso?",
+            "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+          }
+        ]
+      },
+      {
+        "route_name": "AUTHENTICATION_LANDING",
+        "title": "Come accedere all'app IO",
+        "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
+        "faqs": [
+          {
+            "title": "Cos'è SPID?",
+            "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
+          },
+          {
+            "title": "Come puoi ottenere SPID?",
+            "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
+          },
+          {
+            "title": "Hai perso le tue credenziali SPID?",
+            "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
+          },
+          {
+            "title": "Cos'è la CIE?",
+            "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
+          },
+          {
+            "title": "Come puoi ottenere la CIE?",
+            "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
+          },
+          {
+            "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+            "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+          },
+          {
+            "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+            "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere su IO i certificati dei miei familiari?",
+            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
+            "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
+          },
+          {
+            "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+            "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
+            "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
+          },
+          {
+            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Usi Android e non riesci ad aggiornare IO?",
+            "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+          }
+        ]
+      },
+      {
+        "route_name": "MESSAGES_HOME",
+        "title": "Cosa puoi fare nei tuoi Messaggi",
+        "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
+        "faqs": [
+          {
+            "title": "Che tipo di messaggi posso ricevere?",
+            "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
+          },
+          {
+            "title": "Cosa succede se archivio i messaggi?",
+            "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
+          },
+          {
+            "title": "I messaggi possono essere cancellati?",
+            "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
+          },
+          {
+            "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+            "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+          },
+          {
+            "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+            "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Posso ricevere su IO i certificati dei miei familiari?",
+            "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
+            "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+          },
+          {
+            "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
+            "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+          },
+          {
+            "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+            "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
+            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+            "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+            "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+          },
+          {
+            "title": "Usi Android e non riesci ad aggiornare IO?",
+            "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+          }
+        ]
       }
-   },
-   "en": {
-      "screens": [
-         {
-            "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
-            "title": "Pay with your supermarket card",
-            "content": "Here you can add your supermarket card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
-            "faqs": [
-               {
-                  "title": "Which supermarket cards can I add?",
-                  "body": "You can add only supermarket cards that allow you to pay. Supermarket cards that allow you to collect points or get access to discounts only are not valid."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
-            "title": "Pay with your PagoBANCOMAT card",
-            "content": "Here you can add your PagoBANCOMAT card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet. Before proceeding with the addition of your PagoBANCOMAT cards, please read the privacy policy.",
-            "faqs": [
-               {
-                  "title": "Why can't I find my bank?",
-                  "body": "Probably your PagoBANCOMAT card has been issued by a different bank. If you press “Add”, IO will search for all the PagoBANCOMAT cards in your name based on your tax code, which is deducted from the SPID or CIE you used to log in."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ADD_CARD",
-            "title": "Pay with a credit, debit, or prepaid card",
-            "content": "Here you can add your credit, debit, or prepaid card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
-            "faqs": [
-               {
-                  "title": "Where do I find the security code?",
-                  "body": "The security code, also called CVV or CVS, is a three-digit code on the back of your card. In American Express cards it's called CID, it has four digits and is located on the front. If you can't find the security code, your card probably isn't enabled for online payments."
-               },
-               {
-                  "title": "I’m having trouble adding my card. What can I do?",
-                  "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n*Your card is not enabled for online purchases; \n\n*Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page] (https://io.italia.it/metodi-pagamento/)."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_PRIVATIVE_DETAIL",
-            "title": "Your supermarket card",
-            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-            "faqs": [
-               {
-                  "title": "How can I set this payment method as favorite?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-               },
-               {
-                  "title": "How can I delete this payment method?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_BANCOMAT_DETAIL",
-            "title": "Your PagoBANCOMAT card",
-            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-            "faqs": [
-               {
-                  "title": "How can I set this payment method as favorite?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-               },
-               {
-                  "title": "How can I delete this payment method?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-               },
-               {
-                  "title": "Why is the bank's name and logo different from the name and logo on my card?",
-                  "body": "Your PagoBANCOMAT card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
-               },
-               {
-                  "title": "Why does it say my card is not compatible with in-app payments?",
-                  "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n*Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n*Add the second circuit, if your card has the security code and is already enabled for online payments."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_PAYPAL_DETAIL",
-            "title": "Your PayPal account",
-            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-            "faqs": [
-               {
-                  "title": "How can I set this payment method as favorite?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-               },
-               {
-                  "title": "How can I delete this payment method?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_CREDIT_CARD_DETAIL",
-            "title": "Your card",
-            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-            "faqs": [
-               {
-                  "title": "How can I set this payment method as favorite?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-               },
-               {
-                  "title": "How can I delete this payment method?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_HOME",
-            "title": "What can you do in your Wallet",
-            "content": "In the Wallet you can find the payment methods you have added, the bonuses and initiatives you have joined and the history of transactions made with pagoPA, the platform for payments to the Public Administration. Here, you can also pay all the payment notices with the pagoPA logo.",
-            "faqs": [
-               {
-                  "title": "How can I pay on IO?",
-                  "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page] (https://io.italia.it/metodi-pagamento)."
-               },
-               {
-                  "title": "How do I add a payment method?",
-                  "body": "Go to the Wallet, press “Add”, and then “Payment method”. Select the method you want to add and enter the required information."
-               },
-               {
-                  "title": "What bonuses, discounts or other initiatives can I apply for?",
-                  "body": "Go to Wallet, select “Add” and “Discounts, bonuses and other initiatives”. You will see a list with all the bonuses and initiatives you can apply for through IO."
-               },
-               {
-                  "title": "I have trouble adding a payment method. What can I do?",
-                  "body": "Go to the [payment method addition status page] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
-               },
-               {
-                  "title": "How can I delete a payment method?",
-                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
-               },
-               {
-                  "title": "I have trouble with a payment. What can I do?",
-                  "body": "Go to [your payment status page] (ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
-               },
-               {
-                  "title": "Where do I find the payments I have made?",
-                  "body": "In the Wallet you will find a list of successful payments you have made through IO. The list also includes payments made through the partner institutions' website or app, if you logged in with SPID."
-               },
-               {
-                  "title": "Can I pay a notice that I did not receive through IO?",
-                  "body": "Yes, if the notice features the pagoPA logo and QR code or Notice Code. To do so, go to the Wallet, scan the QR or enter the Notice Code and complete the payment."
-               },
-               {
-                  "title": "What is a QR code?",
-                  "body": "The QR code is a square image made of white and black elements. When you scan it with a device's camera, it provides direct access to digital content, such as a website, a payment, or an item.\nThe QR code you find on payment notices is linked to a Notice Code. If you go to your Wallet, press 'Pay Notice' and scan the code with your camera, you can pay the notice without having to manually enter information such as a description, amount or tax code."
-               },
-               {
-                  "title": "What is pagoPA?",
-                  "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website] (https://www.pagopa.gov.it/)."
-               },
-               {
-                  "title": "How can I learn more about digital payments?",
-                  "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section] (https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
-            "title": "Add the second network of your PagoBANCOMAT card",
-            "content": "In order to properly add the international network associated to your PagoBANCOMAT card, we need to know if you have ever used this card online, so that we can redirect you to the relevant page.",
-            "faqs": [
-               {
-                  "title": "How do I understand if my card is enabled for online payments?",
-                  "body": "Your card must have a security code: it is a 3 digit code and is printed on the back. If you can't find it, it means that you can only use your card in stores.\n\n Also make sure that you have enabled the 3D Secure service (Mastercard Identity Check for Mastercard cards and Verified By Visa/Visa Secure for Visa cards). For more information, go to your home banking or contact your bank."
-               },
-               {
-                  "title": "My card has the security code, but I still can't add it to the Wallet.",
-                  "body": "After entering your card details, your bank runs a check, usually via SMS or with a notification through its app. Follow the instructions given by your bank and, in case of trouble, contact their customer service.\n\nIf you do not receive any message (or the transaction is denied) it means that your card is not enabled for online payments. Contact your bank and ask how to activate 3D Secure (Mastercard Identity Check for Mastercard cards and Verified By Visa/Visa Secure for Visa cards)."
-               },
-               {
-                  "title": "I have already added the second network. What should I do?",
-                  "body": "If you have already added the international network to the Wallet as a “debit/credit card”, there is no need to add the card again with this feature."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_COBADGE_START",
-            "title": "Add the second network of your PagoBANCOMAT card",
-            "content": "This feature allows you to search for all the cards with international network (Maestro, Mastercard, Visa and V-Pay) in your name.",
-            "faqs": [
-               {
-                  "title": "Can I add cards with an international network?",
-                  "body": "Yes, you can add debit or credit cards with an international network (Maestro, Mastercard, VISA and V-Pay), even if they are not enabled for online payments. The cards must be in your name and issued by the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
-               },
-               {
-                  "title": "Why can't I find any cards?",
-                  "body": "The service searches only for international network cards in your name. Make sure that the card is actually in your name and is issued by one of the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
-            "title": "Add the second network of your PagoBANCOMAT card",
-            "content": "Here you can see all the cards in your name with an international network (Maestro, Mastercard, Visa and V-Pay), issued by the banks participating in the service. If you don't want to add one of the cards listed, press 'Skip' and go to the next one.",
-            "faqs": [
-               {
-                  "title": "Why is the expiration date different?",
-                  "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
-               },
-               {
-                  "title": "Why is the card number different?",
-                  "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
-               },
-               {
-                  "title": "I have already added the second network, what should I do?",
-                  "body": "If you have already added the international network to the Wallet as a “debit/credit card”, there is no need to add the card again with this feature."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_COBADGE_DETAIL",
-            "title": "Your card with international network",
-            "content": "Here you can see the details of your international network card. You can see the logo of the bank that issued the card, the expiration date and the logo and number of the international network.",
-            "faqs": [
-               {
-                  "title": "What can I do here?",
-                  "body": "You can enable or disable some features for this payment method.\n\n You can also delete this payment method from your Wallet."
-               },
-               {
-                  "title": "Why is the bank's name and logo different from the name and logo on my card?",
-                  "body": "Your card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
-               },
-               {
-                  "title": "Why is the expiration date different?",
-                  "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
-               },
-               {
-                  "title": "Why is the card number different?",
-                  "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
-               }
-            ]
-         },
-         {
-            "route_name": "UADONATION_ROUTES_WEBVIEW",
-            "title": "Donations Ukraine",
-            "content": "In this page, you can make a donation to charities assisting the civilian victims of the crisis in Ukraine.",
-            "faqs": [
-               {
-                  "title": "How can I make a donation?",
-                  "body": "To donate, choose a charity from the list. Then select the amount you want to donate and press 'Continue'. Use a supported payment method or select it from your Wallet. Finally, press 'Pay' to complete the donation."
-               },
-               {
-                  "title": "What payment methods can I use to make the donation?",
-                  "body": "You can donate with a Visa, Maestro and Mastercard credit, debit or prepaid card and with PayPal."
-               },
-               {
-                  "title": "Is there a minimum amount?",
-                  "body": "Yes, you can donate from a minimum of €5 to a maximum of €200. If you want to donate higher amounts, you can repeat the donation."
-               },
-               {
-                  "title": "Is there a commission cost associated with the donation?",
-                  "body": " If you donate with a Visa, Maestro and Mastercard credit, debit or prepaid card, no commissions are charged."
-               },
-               {
-                  "title": "After donating, I did not receive the email with the receipt. What can I do?",
-                  "body": "After donating, you will receive an email with the receipt. If you don't, check your spam folder and make sure the address you find under Profile > Your Information is correct. We recommend that you keep your receipt, along with original documentation of the payment (such as the bank or credit card statement) for tax purposes."
-               },
-               {
-                  "title": "I represent a charity: can I participate in the initiative?",
-                  "body": "For information on how to participate in the initiative, email affari.istituzionali@pagopa.it."
-               }
-            ]
-         }
-      ],
-      "idps": {
-         "arubaid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
-            "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-            "phone": "003905750504",
-            "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-            "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-            "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-            "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-         },
-         "infocertid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of InfoCert by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://help.infocert.it/Cerca?searchText=spid) gathered by your Identity Provider.",
-            "helpdesk_form": "https://contatta.infocert.it/ticket/",
-            "phone": "00390654641489",
-            "web_site": "https://identitadigitale.infocert.it/",
-            "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-            "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-         },
-         "intesaid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Intesa by selecting  one of the options presented below.",
-            "email": "hdintesa@advalia.com",
-            "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-            "phone": "800805093",
-            "phone_international": "00390287119396",
-            "web_site": "https://www.intesa.it/intesaid",
-            "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-         },
-         "lepidaid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Lepida by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://id.lepida.it/docs/manuale_utente.pdf).",
-            "email": "helpdesk@lepida.it",
-            "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-            "phone": "800445500",
-            "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-            "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-            "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-         },
-         "namirialid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Namirial by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) gathered by your Identity Provider.",
-            "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-            "phone": "003907163494",
-            "web_site": "https://www.namirialtsp.com/spid/",
-            "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-            "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-         },
-         "posteid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Poste Italiane by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.poste.it/faq-poste-id.html) gathered by your Identity Provider and the [User Guide](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-            "helpdesk_form": "https://www.poste.it/scrivici.html",
-            "phone": "800007777",
-            "web_site": "https://posteid.poste.it",
-            "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-            "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-         },
-         "sielteid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.sielteid.it/faq.html) gathered by your Identity Provider and the [User Guide](https://www.sielteid.it/faq.html).",
-            "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-            "phone": "00390957171301",
-            "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-            "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-         },
-         "spiditalia": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  the button below. \n For further details you can refer to the [FAQ](https://www.register.it/spid#pgc-23051-10-0) gathered by your Identity Provider and the [User Guide](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-            "phone": "+390355787979",
-            "web_site": "https://www.register.it/spid/ ",
-            "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-            "recover_password": "https://spid.register.it/selfcare/recovery/password"
-         },
-         "timid": {
-            "description": "For problems encountered during the authentication process, you can reach the support desk of Tim by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf).",
-            "email": "supportotimid@telecomitalia.it",
-            "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-            "phone": "800405800",
-            "web_site": "https://spid.tim.it/tim-id-portal",
-            "recover_username": "https://login.id.tim.it/mps/fu.php",
-            "recover_password": "https://login.id.tim.it/mps/fp.php"
-         }
+    ],
+    "idps": {
+      "arubaid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
+        "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+        "phone": "003905750504",
+        "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+        "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+        "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+        "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+      },
+      "infocertid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
+        "helpdesk_form": "https://contatta.infocert.it/ticket/",
+        "phone": "00390654641489",
+        "web_site": "https://identitadigitale.infocert.it/",
+        "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+        "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+      },
+      "intesaid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
+        "email": "hdintesa@advalia.com",
+        "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+        "phone": "800805093",
+        "phone_international": "00390287119396",
+        "web_site": "https://www.intesa.it/intesaid",
+        "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+      },
+      "lepidaid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
+        "email": "helpdesk@lepida.it",
+        "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+        "phone": "800445500",
+        "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+        "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+        "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+      },
+      "namirialid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
+        "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+        "phone": "003907163494",
+        "web_site": "https://www.namirialtsp.com/spid/",
+        "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+        "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+      },
+      "posteid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+        "helpdesk_form": "https://www.poste.it/scrivici.html",
+        "phone": "800007777",
+        "web_site": "https://posteid.poste.it",
+        "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+        "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+      },
+      "sielteid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
+        "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+        "phone": "00390957171301",
+        "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+        "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+      },
+      "spiditalia": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+        "phone": "+390355787979",
+        "web_site": "https://www.register.it/spid/ ",
+        "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+        "recover_password": "https://spid.register.it/selfcare/recovery/password"
+      },
+      "timid": {
+        "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
+        "email": "supportotimid@telecomitalia.it",
+        "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+        "phone": "800405800",
+        "web_site": "https://spid.tim.it/tim-id-portal",
+        "recover_username": "https://login.id.tim.it/mps/fu.php",
+        "recover_password": "https://login.id.tim.it/mps/fp.php"
       }
-   }
+    }
+  },
+  "en": {
+    "screens": [
+      {
+        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+        "title": "Pay with your supermarket card",
+        "content": "Here you can add your supermarket card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
+        "faqs": [
+          {
+            "title": "Which supermarket cards can I add?",
+            "body": "You can add only supermarket cards that allow you to pay. Supermarket cards that allow you to collect points or get access to discounts only are not valid."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
+        "title": "Pay with your PagoBANCOMAT card",
+        "content": "Here you can add your PagoBANCOMAT card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet. Before proceeding with the addition of your PagoBANCOMAT cards, please read the privacy policy.",
+        "faqs": [
+          {
+            "title": "Why can't I find my bank?",
+            "body": "Probably your PagoBANCOMAT card has been issued by a different bank. If you press “Add”, IO will search for all the PagoBANCOMAT cards in your name based on your tax code, which is deducted from the SPID or CIE you used to log in."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ADD_CARD",
+        "title": "Pay with a credit, debit, or prepaid card",
+        "content": "Here you can add your credit, debit, or prepaid card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
+        "faqs": [
+          {
+            "title": "Where do I find the security code?",
+            "body": "The security code, also called CVV or CVS, is a three-digit code on the back of your card. In American Express cards it's called CID, it has four digits and is located on the front. If you can't find the security code, your card probably isn't enabled for online payments."
+          },
+          {
+            "title": "I’m having trouble adding my card. What can I do?",
+            "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n*Your card is not enabled for online purchases; \n\n*Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page] (https://io.italia.it/metodi-pagamento/)."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_PRIVATIVE_DETAIL",
+        "title": "Your supermarket card",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_BANCOMAT_DETAIL",
+        "title": "Your PagoBANCOMAT card",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+          },
+          {
+            "title": "Why is the bank's name and logo different from the name and logo on my card?",
+            "body": "Your PagoBANCOMAT card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
+          },
+          {
+            "title": "Why does it say my card is not compatible with in-app payments?",
+            "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n*Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n*Add the second circuit, if your card has the security code and is already enabled for online payments."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_PAYPAL_DETAIL",
+        "title": "Your PayPal account",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_CREDIT_CARD_DETAIL",
+        "title": "Your card",
+        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+        "faqs": [
+          {
+            "title": "How can I set this payment method as favorite?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+          },
+          {
+            "title": "How can I delete this payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_HOME",
+        "title": "What can you do in your Wallet",
+        "content": "In the Wallet you can find the payment methods you have added, the bonuses and initiatives you have joined and the history of transactions made with pagoPA, the platform for payments to the Public Administration. Here, you can also pay all the payment notices with the pagoPA logo.",
+        "faqs": [
+          {
+            "title": "How can I pay on IO?",
+            "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page] (https://io.italia.it/metodi-pagamento)."
+          },
+          {
+            "title": "How do I add a payment method?",
+            "body": "Go to the Wallet, press “Add”, and then “Payment method”. Select the method you want to add and enter the required information."
+          },
+          {
+            "title": "What bonuses, discounts or other initiatives can I apply for?",
+            "body": "Go to Wallet, select “Add” and “Discounts, bonuses and other initiatives”. You will see a list with all the bonuses and initiatives you can apply for through IO."
+          },
+          {
+            "title": "I have trouble adding a payment method. What can I do?",
+            "body": "Go to the [payment method addition status page] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
+          },
+          {
+            "title": "How can I delete a payment method?",
+            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
+          },
+          {
+            "title": "I have trouble with a payment. What can I do?",
+            "body": "Go to [your payment status page] (ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
+          },
+          {
+            "title": "Where do I find the payments I have made?",
+            "body": "In the Wallet you will find a list of successful payments you have made through IO. The list also includes payments made through the partner institutions' website or app, if you logged in with SPID."
+          },
+          {
+            "title": "Can I pay a notice that I did not receive through IO?",
+            "body": "Yes, if the notice features the pagoPA logo and QR code or Notice Code. To do so, go to the Wallet, scan the QR or enter the Notice Code and complete the payment."
+          },
+          {
+            "title": "What is a QR code?",
+            "body": "The QR code is a square image made of white and black elements. When you scan it with a device's camera, it provides direct access to digital content, such as a website, a payment, or an item.\nThe QR code you find on payment notices is linked to a Notice Code. If you go to your Wallet, press 'Pay Notice' and scan the code with your camera, you can pay the notice without having to manually enter information such as a description, amount or tax code."
+          },
+          {
+            "title": "What is pagoPA?",
+            "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website] (https://www.pagopa.gov.it/)."
+          },
+          {
+            "title": "How can I learn more about digital payments?",
+            "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section] (https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
+        "title": "Add the second network of your PagoBANCOMAT card",
+        "content": "In order to properly add the international network associated to your PagoBANCOMAT card, we need to know if you have ever used this card online, so that we can redirect you to the relevant page.",
+        "faqs": [
+          {
+            "title": "How do I understand if my card is enabled for online payments?",
+            "body": "Your card must have a security code: it is a 3 digit code and is printed on the back. If you can't find it, it means that you can only use your card in stores.\n\n Also make sure that you have enabled the 3D Secure service (Mastercard Identity Check for Mastercard cards and Verified By Visa/Visa Secure for Visa cards). For more information, go to your home banking or contact your bank."
+          },
+          {
+            "title": "My card has the security code, but I still can't add it to the Wallet.",
+            "body": "After entering your card details, your bank runs a check, usually via SMS or with a notification through its app. Follow the instructions given by your bank and, in case of trouble, contact their customer service.\n\nIf you do not receive any message (or the transaction is denied) it means that your card is not enabled for online payments. Contact your bank and ask how to activate 3D Secure (Mastercard Identity Check for Mastercard cards and Verified By Visa/Visa Secure for Visa cards)."
+          },
+          {
+            "title": "I have already added the second network. What should I do?",
+            "body": "If you have already added the international network to the Wallet as a “debit/credit card”, there is no need to add the card again with this feature."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_START",
+        "title": "Add the second network of your PagoBANCOMAT card",
+        "content": "This feature allows you to search for all the cards with international network (Maestro, Mastercard, Visa and V-Pay) in your name.",
+        "faqs": [
+          {
+            "title": "Can I add cards with an international network?",
+            "body": "Yes, you can add debit or credit cards with an international network (Maestro, Mastercard, VISA and V-Pay), even if they are not enabled for online payments. The cards must be in your name and issued by the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
+          },
+          {
+            "title": "Why can't I find any cards?",
+            "body": "The service searches only for international network cards in your name. Make sure that the card is actually in your name and is issued by one of the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
+        "title": "Add the second network of your PagoBANCOMAT card",
+        "content": "Here you can see all the cards in your name with an international network (Maestro, Mastercard, Visa and V-Pay), issued by the banks participating in the service. If you don't want to add one of the cards listed, press 'Skip' and go to the next one.",
+        "faqs": [
+          {
+            "title": "Why is the expiration date different?",
+            "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
+          },
+          {
+            "title": "Why is the card number different?",
+            "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
+          },
+          {
+            "title": "I have already added the second network, what should I do?",
+            "body": "If you have already added the international network to the Wallet as a “debit/credit card”, there is no need to add the card again with this feature."
+          }
+        ]
+      },
+      {
+        "route_name": "WALLET_COBADGE_DETAIL",
+        "title": "Your card with international network",
+        "content": "Here you can see the details of your international network card. You can see the logo of the bank that issued the card, the expiration date and the logo and number of the international network.",
+        "faqs": [
+          {
+            "title": "What can I do here?",
+            "body": "You can enable or disable some features for this payment method.\n\n You can also delete this payment method from your Wallet."
+          },
+          {
+            "title": "Why is the bank's name and logo different from the name and logo on my card?",
+            "body": "Your card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
+          },
+          {
+            "title": "Why is the expiration date different?",
+            "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
+          },
+          {
+            "title": "Why is the card number different?",
+            "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
+          }
+        ]
+      },
+      {
+        "route_name": "UADONATION_ROUTES_WEBVIEW",
+        "title": "Donations Ukraine",
+        "content": "In this page, you can make a donation to charities assisting the civilian victims of the crisis in Ukraine.",
+        "faqs": [
+          {
+            "title": "How can I make a donation?",
+            "body": "To donate, choose a charity from the list. Then select the amount you want to donate and press 'Continue'. Use a supported payment method or select it from your Wallet. Finally, press 'Pay' to complete the donation."
+          },
+          {
+            "title": "What payment methods can I use to make the donation?",
+            "body": "You can donate with a Visa, Maestro and Mastercard credit, debit or prepaid card and with PayPal."
+          },
+          {
+            "title": "Is there a minimum amount?",
+            "body": "Yes, you can donate from a minimum of €5 to a maximum of €200. If you want to donate higher amounts, you can repeat the donation."
+          },
+          {
+            "title": "Is there a commission cost associated with the donation?",
+            "body": " If you donate with a Visa, Maestro and Mastercard credit, debit or prepaid card, no commissions are charged."
+          },
+          {
+            "title": "After donating, I did not receive the email with the receipt. What can I do?",
+            "body": "After donating, you will receive an email with the receipt. If you don't, check your spam folder and make sure the address you find under Profile > Your Information is correct. We recommend that you keep your receipt, along with original documentation of the payment (such as the bank or credit card statement) for tax purposes."
+          },
+          {
+            "title": "I represent a charity: can I participate in the initiative?",
+            "body": "For information on how to participate in the initiative, email affari.istituzionali@pagopa.it."
+          }
+        ]
+      }
+    ],
+    "idps": {
+      "arubaid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
+        "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+        "phone": "003905750504",
+        "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+        "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+        "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+        "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
+      },
+      "infocertid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of InfoCert by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://help.infocert.it/Cerca?searchText=spid) gathered by your Identity Provider.",
+        "helpdesk_form": "https://contatta.infocert.it/ticket/",
+        "phone": "00390654641489",
+        "web_site": "https://identitadigitale.infocert.it/",
+        "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+        "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
+      },
+      "intesaid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Intesa by selecting  one of the options presented below.",
+        "email": "hdintesa@advalia.com",
+        "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+        "phone": "800805093",
+        "phone_international": "00390287119396",
+        "web_site": "https://www.intesa.it/intesaid",
+        "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
+      },
+      "lepidaid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Lepida by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://id.lepida.it/docs/manuale_utente.pdf).",
+        "email": "helpdesk@lepida.it",
+        "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+        "phone": "800445500",
+        "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+        "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+        "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+      },
+      "namirialid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Namirial by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) gathered by your Identity Provider.",
+        "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+        "phone": "003907163494",
+        "web_site": "https://www.namirialtsp.com/spid/",
+        "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+        "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+      },
+      "posteid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Poste Italiane by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.poste.it/faq-poste-id.html) gathered by your Identity Provider and the [User Guide](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+        "helpdesk_form": "https://www.poste.it/scrivici.html",
+        "phone": "800007777",
+        "web_site": "https://posteid.poste.it",
+        "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+        "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+      },
+      "sielteid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  one of the options presented below. \n For further details you can refer to the [FAQ](https://www.sielteid.it/faq.html) gathered by your Identity Provider and the [User Guide](https://www.sielteid.it/faq.html).",
+        "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+        "phone": "00390957171301",
+        "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+        "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+      },
+      "spiditalia": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Sielte by selecting  the button below. \n For further details you can refer to the [FAQ](https://www.register.it/spid#pgc-23051-10-0) gathered by your Identity Provider and the [User Guide](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+        "phone": "+390355787979",
+        "web_site": "https://www.register.it/spid/ ",
+        "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+        "recover_password": "https://spid.register.it/selfcare/recovery/password"
+      },
+      "timid": {
+        "description": "For problems encountered during the authentication process, you can reach the support desk of Tim by selecting  one of the options presented below. \n For further details you can refer to the [User Guide](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf).",
+        "email": "supportotimid@telecomitalia.it",
+        "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+        "phone": "800405800",
+        "web_site": "https://spid.tim.it/tim-id-portal",
+        "recover_username": "https://login.id.tim.it/mps/fu.php",
+        "recover_password": "https://login.id.tim.it/mps/fp.php"
+      }
+    }
+  }
 }

--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -2,318 +2,320 @@
    "version": 1,
    "it": {
       "screens": [
-        {
-        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
-        "title": "Paga con la tua carta supermercato",
-        "content": "In questa pagina puoi aggiungere la tua carta supermercato come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
-        "faqs": [
-          {
-            "title": "Quali carte supermercato posso aggiungere?",
-            "body": "Puoi aggiungere soltanto le carte supermercato che permettono di pagare. Non sono valide le carte supermercato che non consentono di effettuare pagamenti, ma solo di accumulare punti o avere accesso a sconti."
-          }
-          {
-        "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
-        "title": "Paga con la tua carta PagoBANCOMAT",
-        "content": "In questa pagina puoi aggiungere una carta PagoBANCOMAT come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio. Prima di procedere all'aggiunta delle tue carte PagoBANCOMAT, ti invitiamo a leggere l'informativa.",
-        "faqs": [
-          {
-            "title": "Perché non trovo la mia banca?",
-            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Se premi su “Continua”, IO cercherà tutte le carte PagoBANCOMAT a te intestate sulla base del tuo codice fiscale, che viene recuperato dallo SPID o dalla CIE con cui hai effettuato l'accesso."
-          }
-        ]
-      },
-        {
-        "route_name": "WALLET_ADD_CARD",
-        "title": "Paga con una carta credito, debito o prepagata",
-        "content": "In questa pagina puoi aggiungere una carta di credito, debito o prepagata come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
-        "faqs": [
-          {
-            "title": "Dove trovo il codice di sicurezza?",
-            "body": "Il codice di sicurezza, chiamato anche CVV o CVS, è un codice a tre cifre che si trova sul retro della tua carta. Sulle carte American Express si chiama CID, è a quattro cifre e si trova sul fronte. Se non lo trovi, probabilmente la tua carta non è abilitata ai pagamenti online."
-          },
-          {
-            "title": "Non riesco ad aggiungere la mia carta. Come mai?",
-            "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n*La tua carta non è abilitata agli acquisti online;\n\n*La tua carta è stata messa “in pausa”;\n\n*Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
-          }
-        ]
-      },
-        {
-        "route_name": "WALLET_PRIVATIVE_DETAIL",
-        "title": "La tua carta supermercato",
-        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-        "faqs": [
-          {
-            "title": "Come posso impostare questo metodo di pagamento come preferito?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-          },
-          {
-            "title": "Come posso eliminare questo metodo di pagamento?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-          }
-        ]
-      },
-        {
-        "route_name": "WALLET_BANCOMAT_DETAIL",
-        "title": "La tua carta PagoBANCOMAT",
-        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-        "faqs": [
-          {
-            "title": "Come posso impostare questo metodo di pagamento come preferito?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-          },
-          {
-            "title": "Come posso eliminare questo metodo di pagamento?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-          },
-        {
-            "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-            "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-          },
-          {
-            "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
-            "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n*Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n*Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
-          }
-        ]
-      },
-        {
-        "route_name": "WALLET_PAYPAL_DETAIL",
-        "title": "Il tuo account PayPal",
-        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-        "faqs": [
-          {
-            "title": "Come posso impostare questo metodo di pagamento come preferito?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-          },
-          {
-            "title": "Come posso eliminare questo metodo di pagamento?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-          }
-        ]
-      },
-        {
-        "route_name": "WALLET_CREDIT_CARD_DETAIL",
-        "title": "La tua carta",
-        "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
-        "faqs": [
-          {
-            "title": "Come posso impostare questo metodo di pagamento come preferito?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
-          },
-          {
-            "title": "Come posso eliminare questo metodo di pagamento?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-          }
-        ]
-      },
-        {
-        "route_name": "WALLET_HOME",
-        "title": "Cosa puoi fare nel tuo Portafoglio",
-        "content": "Nel Portafoglio trovi i metodi di pagamento che hai aggiunto, i bonus e le iniziative a cui hai aderito e lo storico delle transazioni effettuate con pagoPA, la piattaforma dei pagamenti verso la Pubblica Amministrazione. In questa sezione, puoi anche pagare tutti gli avvisi di pagamento cartacei con il logo pagoPA.",
-        "faqs": [
-          {
-            "title": "Come posso pagare su IO?",
-            "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento)."
-          },
-          {
-            "title": "Come posso aggiungere un metodo di pagamento?",
-            "body": "Vai al Portafoglio, premi “Aggiungi” e “Metodo di Pagamento”. Poi, seleziona il metodo che vuoi aggiungere e inserisci i dati richiesti."
-          },
-          {
-            "title": "Quali bonus, sconti o altre iniziative posso richiedere?",
-            "body": "Vai al Portafoglio, premi “Aggiungi” e “Sconti, bonus e altre iniziative”. Comparirà una lista con tutti i bonus e le iniziative che puoi richiedere tramite l’app IO."
-          },
-          {
-            "title": "Non riesco ad aggiungere un metodo di pagamento. Cosa posso fare?",
-            "body": "Accedi alla pagina [stato aggiunta metodi di pagamento] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
-          },
-          {
-            "title": "Come posso eliminare un metodo di pagamento?",
-            "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
-          },
-          {
-            "title": "Ho un problema con un pagamento. Cosa posso fare?",
-            "body": "Accedi alla pagina [stato dei tuoi pagamenti] (ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
-          },
-          {
-            "title": "Dove trovo i pagamenti che ho effettuato?",
-            "body": "Nel Portafoglio trovi una lista che contiene i pagamenti effettuati con successo tramite l’app IO. La lista include anche i pagamenti effettuati tramite il sito o l’app degli enti aderenti, se ti sei autenticato con SPID."
-          },
-          {
-            "title": "Posso pagare un avviso che non ho ricevuto tramite IO?",
-            "body": "Sì, se sull’avviso sono presenti il logo pagoPA e il codice QR o il Codice Avviso. Per farlo, vai nel Portafoglio, scansiona il QR o inserisci il Codice Avviso e completa il pagamento."
-          },
-          {
-            "title": "Che cos’è un codice QR?",
-            "body": "Il codice QR è un’immagine quadrata composta da elementi bianchi e neri. Se inquadrato dalla fotocamera di un telefono permette di accedere a contenuti digitali, come ad esempio un sito web, un pagamento o un articolo.\n\nIl codice QR che trovi sugli avvisi di pagamento è associato a un Codice Avviso. Se vai al tuo Portafoglio, premi su “Paga un avviso” e inquadri il codice con la fotocamera, puoi pagare l’avviso senza dover inserire manualmente informazioni come causale, cifra o codice fiscale."
-          },
-          {
-            "title": "Che cos’è pagoPA?",
-            "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA] (https://www.pagopa.gov.it/)."
-          },
-          {
-            "title": "Come posso saperne di più sui pagamenti digitali?",
-            "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata] (https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti] (https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico] (https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
-          },
-        ]
-      },
-        {
-        "route_name": "UADONATION_ROUTES_WEBVIEW",
-        "title": "Donazioni Ucraina",
-        "content": "In questa pagina, puoi fare una donazione alle organizzazioni umanitarie che assistono le vittime civili della crisi in Ucraina.",
-        "faqs": [
-          {
-            "title": "Come posso donare?",
-            "body": "Per donare, scegli un’organizzazione umanitaria tra quelle che trovi nella lista. Poi, seleziona l’importo che vuoi donare e premi “Continua”. Usa un metodo di pagamento compatibile o selezionalo dal Portafoglio. Infine, premi “Paga” per completare la donazione."
-          },
-          {
-            "title": "Con che metodi di pagamento posso fare la donazione?",
-            "body": "Puoi donare con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard e con conto PayPal."
-          },
-          {
-            "title": "C'è un importo minimo?",
-            "body": "Sì, puoi donare da un minimo di 5 € a un massimo di 200 €. Se vuoi donare importi superiori, ripeti la donazione."
-          },
-          {
-            "title": "La donazione prevede dei costi di commissione?",
-            "body": "Se doni con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard non hai costi di commissione."
-          },
-          {
-            "title": "Dopo la donazione, non ho ricevuto nessuna email con la ricevuta. Cosa posso fare?",
-            "body": "Dopo la donazione, ti invieremo un'email con la ricevuta. Se non la ricevi, guarda nella cartella spam e verifica che l'indirizzo che trovi nella sezione Profilo > I tuoi dati sia corretto. Ti consigliamo di conservare la ricevuta della donazione, insieme alla documentazione originale del versamento (come l'estratto conto della banca o della carta di credito) per fini fiscali."
-          },
-          {
-            "title": "Rappresento un'organizzazione umanitaria: posso partecipare all'iniziativa?",
-            "body": "Per avere informazioni su come partecipare all'iniziativa, scrivi un'email a affari.istituzionali@pagopa.it."
-          }
-        ]
-      },
          {
-        "route_name": "WALLET_ONBOARDING_PAYPAL_SEARCH_PSP",
-        "title": "Scegli il gestore della transazione",
-        "content": "Il gestore della transazione, ovvero il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore, può applicare ad ogni pagamento una commissione variabile. In questa pagina, puoi scegliere quale gestore della transazione utilizzare. Potrai modificare questa scelta ad ogni pagamento, scegliendo in base alla commissione proposta.",
-        "faqs": [
-          {
-            "title": "Cos’è il gestore della transazione?",
-            "body": "Il gestore della transazione, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), è il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore. Per svolgere questo servizio, il gestore può applicare ogni volta una commissione.\n\npagoPA ti permette di effettuare pagamenti elettronici tramite uno dei gestori della transazione aderenti. È questo il tramite che ti permette di pagare un avviso, una retta, un bollo o un tributo direttamente in app."
-          },
-          {
-            "title": "Perché devo scegliere il gestore della transazione?",
-            "body": "Quando effettui un pagamento, IO ti mostra tutti i gestori della transazione che puoi utilizzare, così che tu possa scegliere quello che ti conviene di più a seconda della commissione proposta. Ad incassare questa commissione non è pagoPA, ma il gestore stesso."
-          },
-          {
-            "title": "Quale gestore devo scegliere?",
-            "body": "Puoi selezionare il gestore che preferisci, che tu sia cliente o no e anche se non lo hai mai utilizzato prima. La scelta del gestore non è definitiva: puoi modificarla ad ogni pagamento."
-          },
-          {
-            "title": "A cosa è dovuto il costo della transazione?",
-            "body": "Per sostenere i costi di gestione e garantire la sicurezza del trasferimento di denaro, ogni gestore della transazione può applicare una commissione variabile. La commissione varia a seconda delle politiche commerciali e delle condizioni contrattuali sottoscritte col gestore che hai scelto. IO ti mostrerà sempre il costo della transazione indicato dal gestore della transazione, per permetterti di scegliere quello più conveniente."
-          },
-           {
-            "title": "Non riesco ad aggiungere PayPal come metodo di pagamento.",
-            "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
-          }
-        ]
-      },
+            "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+            "title": "Paga con la tua carta supermercato",
+            "content": "In questa pagina puoi aggiungere la tua carta supermercato come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
+            "faqs": [
+               {
+                  "title": "Quali carte supermercato posso aggiungere?",
+                  "body": "Puoi aggiungere soltanto le carte supermercato che permettono di pagare. Non sono valide le carte supermercato che non consentono di effettuare pagamenti, ma solo di accumulare punti o avere accesso a sconti."
+               }
+            ]
+         },
          {
-        "route_name": "WALLET_ONBOARDING_PAYPAL_START",
-        "title": "Paga con PayPal",
-        "content": "In questa pagina potrai aggiungere PayPal come metodo di pagamento nell’app IO.\n\nPayPal ti permette di pagare senza inserire ogni volta i tuoi dati finanziari. Ti permette anche di collegare il tuo conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.",
-        "faqs": [
-          {
-            "title": "Cos’è PayPal?",
-            "body": "PayPal è il servizio che ti consente di pagare, inviare denaro e accettare pagamenti in modo più rapido, semplice e sicuro, senza dover immettere ogni volta i tuoi dati finanziari. Per approfondire o aprire un conto gratuitamente, vai sul sito [paypal.com](https://www.paypal.com/it)."
-          },
-          {
-            "title": "Come funziona?",
-            "body": "Per utilizzare PayPal su IO, registrati con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it) e collega la tua carta di credito, di debito, prepagata o il conto corrente.\n\nPoi, aggiungilo come metodo di pagamento nella sezione Portafoglio di IO. Per farlo, ti verranno richiesti l’indirizzo email e la password del tuo conto PayPal. Dovrai inoltre completare l’autenticazione a due fattori utilizzando una modalità a scelta tra app PayPal, SMS o chiamata."
-          },
-          {
-            "title": "Che vantaggi ho ad utilizzare PayPal per pagare tramite IO?",
-            "body": "PayPal ti permetterà di autorizzare le operazioni di pagamento in modo semplice e veloce, senza che tu debba inserire i tuoi dati finanziari.\n\nPuoi collegare al tuo conto PayPal non solo la carta di credito, di debito o prepagata, ma anche il conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.\n\n[Scopri qui](https://www.paypal.com/it/smarthelp/article/come-faccio-a-collegare-il-mio-conto-bancario-al-mio-conto-paypal-faq686) come collegare il tuo conto bancario a PayPal."
-          },
-          {
-            "title": "Non ho un conto PayPal. Come posso crearne uno?",
-            "body": "Per creare un conto PayPal, devi registrarti con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it). Per farlo, devi essere maggiorenne e collegare almeno un metodo di pagamento."
-          }
-        ]
-      },
+            "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
+            "title": "Paga con la tua carta PagoBANCOMAT",
+            "content": "In questa pagina puoi aggiungere una carta PagoBANCOMAT come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio. Prima di procedere all'aggiunta delle tue carte PagoBANCOMAT, ti invitiamo a leggere l'informativa.",
+            "faqs": [
+               {
+                  "title": "Perché non trovo la mia banca?",
+                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Se premi su “Continua”, IO cercherà tutte le carte PagoBANCOMAT a te intestate sulla base del tuo codice fiscale, che viene recuperato dallo SPID o dalla CIE con cui hai effettuato l'accesso."
+               }
+            ]
+         },
          {
-        "route_name": "MESSAGE_DETAIL",
-        "title": "Dettagli del messaggio",
-        "content": "Qui puoi visualizzare il dettaglio della comunicazione ricevuta da un ente integrato all'app IO. Se hai dubbi o delle domande sul contenuto specifico del messaggio, puoi contattare l'ente utilizzando i recapiti che trovi in fondo a questo messaggio o nella sezione 'Servizi'.",
-        "faqs": [
-          {
-            "title": "Questo messaggio non ti interessa?",
-            "body": "Su IO è possibile disattivare la comunicazione dai servizi che non ti interessano in qualsiasi momento: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi)."
-          },
-          {
-            "title": "C'è un errore nella comunicazione che hai ricevuto?",
-            "body": "Se pensi che ci sia un errore nel messaggio che hai ricevuto, puoi utilizzare i recapiti di contatto dell'ente erogatore del servizio per fare una segnalazione o chiedere chiarimenti. \nI recapiti sono disponibili dall'area dettagli del messaggio oppure nella sezione 'Servizi' dell'app IO, selezionando lo specifico ente e servizio in questione. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
-          },
-          {
-            "title": "Questo ente ha il permesso di scriverti?",
-            "body": "Un ente può inviarti dei messaggi solo se ha una comunicazione specifica da recapitare a te, associata al tuo codice fiscale. Il tuo codice fiscale non viene comunicato dall'app IO all'ente, ma ciascun ente può utilizzare l'app IO per scriverti solo se ha già i tuoi dati (e quindi una relazione con te). \n \nSe non vuoi più ricevere comunicazioni da uno specifico ente, puoi disattivarne i servizi che non ti interessano: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nNella sezione 'Profilo > Preferenze > Gestione servizi' puoi decidere di lasciare accesa la comunicazione di tutti i servizi, oppure scegliere la configurazione manuale per cui dovrai configurare a uno a uno tutti i servizi dalla relativa schermata di dettaglio."
-          },
-          {
-            "title": "Vuoi contattare l'ente?",
-            "body": "Dai dettagli del messaggio puoi visualizzare le informazioni relative allo specifico servizio e ente erogatore. Se segui il link al profilo del servizio trovi le informazioni estese, e i recapiti attraverso i quali puoi contattare l'ente erogatore del servizio. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
-          }
-        ]
-      },
-      {
-        "route_name": "SERVICES_HOME",
-        "title": "Cosa puoi fare nei tuoi Servizi",
-        "content": "Qui puoi visualizzare la lista dei servizi nazionali o locali disponibili su IO. \nPremi sul nome di un servizio per visualizzarne i dettagli.",
-        "faqs": [
-          {
-            "title": "Come gestire i servizi su IO?",
-            "body": "Utilizza le configurazioni disponibili nella sezione 'Profilo > Preferenze > Gestione servizi', oppure le opzioni contenute nel dettaglio di ciascun servizio per decidere come riceverne le comunicazioni (messaggio in app, notifica push, inoltro del messaggio via e-mail). \n \nAttenzione! Vedere la lista completa dei servizi non significa che ti contatteranno servizi che non ti riguardano: gli enti comunicano con te solo se in possesso del tuo codice fiscale e nel momento in cui hanno necessità di inviarti comunicazioni importanti."
-          },
-          {
-            "title": "Puoi contattare gli enti tramite IO?",
-            "body": "Non puoi direttamente contattare gli enti dall'app IO ma puoi visualizzare le loro informazioni di contatto all'interno della sezione 'Servizi', nella scheda di ciascun servizio."
-          }
-        ]
-      },
-      {
-        "route_name": "SERVICE_DETAIL",
-        "title": "Dettagli del Servizio",
-        "content": "In questa schermata puoi visualizzare la descrizione del servizio, l'informativa privacy e condizioni d'uso, i dati di contatto dell'ente o del servizio e puoi configurare le modalità di comunicazione per questo specifico servizio. \n \nRicorda che su IO ti scriveranno solo servizi che hanno qualche informazione personalizzata da comunicarti: non riceverai messaggi di spam o contenuti che non ti riguardano direttamente. \n \nSe vuoi comunque impedire al servizio di contattarti puoi farlo nell'area 'Questo servizio può', disabilitando l'opzione 'Contattarti in app'. \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nDa questa pagina puoi inoltre gestire l'invio di notifiche push e l'inoltro dei messaggi anche al tuo indirizzo e-mail.",
-        "faqs": [
-          {
-            "title": "Cosa succede se disattivi un servizio?",
-            "body": "Non riceverai più le comunicazioni di quello specifico servizio nell'app IO. L'ente che eroga il servizio potrà comunque contattarti o essere contattato attraverso altri canali quali sito, email, numero di telefono o ufficio di pertinenza."
-          },
-          {
-            "title": "Come funzionano le notifiche push?",
-            "body": "Le notifiche push ti informano che è arrivato un nuovo messaggio nell'app IO, e ti invitano a procedere alla lettura. \n \nSe preferisci disattivarle, disabilita nell'area 'Questo servizio può' l'opzione 'Inviarti notifiche push'. Nella sezione Messaggi potrai comunque distinguere i messaggi non letti grazie al pallino blu."
-          },
-          {
-            "title": "Come funziona l'inoltro via email dei messaggi?",
-            "body": "Attivando l'inoltro via email dei messaggi, riceverai all'indirizzo email associato all'app una copia del messaggio che ricevi su IO. \nL'inoltro via mail non è disponibile per alcuni servizi, sulla base di decisioni prese dall'ente in merito alla sensibilità dei contenuti del messaggio stesso."
-          }
-        ]
-      },
-      {
-        "route_name": "PROFILE_PREFERENCES_EMAIL_FORWARDING",
-        "title": "Come gestire l'inoltro dei messaggi",
-        "content": "Qui puoi abilitare o disabilitare l'inoltro al tuo indirizzo e-mail dei messaggi che ricevi su IO."
-      },
-      {
-        "route_name": "PROFILE_PREFERENCES_SERVICES",
-        "title": "Gestisci servizi in app",
-        "content": "Qui puoi decidere come gestire la comunicazione dei servizi. \nL'app IO vuole essere un canale di comunicazione aggiuntivo per gli enti nazionali o locali che hanno qualcosa da dire proprio a te. \nNon manda messaggi broadcast o spam e per questo ti consigliamo di utilizzare la configurazione rapida, mantenendo la comunicazione dei servizi sempre attiva.",
-        "faqs": [
-          {
-            "title": "Perché dovrei usare la configurazione rapida?",
-            "body": "Perchè IO manda solo messaggi utili e rivolti proprio a te: gli enti erogatori dei servizi devono conoscere il tuo codice fiscale per poterti scrivere e questo è garanzia del fatto che hanno già una relazione con te. Usando la configurazione rapida non devi pensare a niente e riceverai i messaggi che ti riguardano anche dai servizi che arriveranno in futuro. \nSe decidi comunque di usare la configurazione manuale, sappi che gli enti potranno contattarti attraverso i canali tradizionali a loro disposizione."
-          },
-          {
-            "title": "Cosa succede se utilizzo la configurazione manuale?",
-            "body": "La configurazione manuale spegne la comunicazione di tutti i servizi, quelli attualmente presenti e quelli che arriveranno in futuro. \nPer ricevere i messaggi dai servizi che ti interessano dovrai configurarli uno a uno dalle relative schede servizio. \nAttenzione! Spegnendo la comunicazione tramite IO, l'ente che eroga il servizio potrà comunque contattarti attraverso i canali tradizionali disponibili (es. e-mail, posta, SMS)."
-          }
-        ]
-      },
+            "route_name": "WALLET_ADD_CARD",
+            "title": "Paga con una carta credito, debito o prepagata",
+            "content": "In questa pagina puoi aggiungere una carta di credito, debito o prepagata come metodo di pagamento. Potrai modificare le impostazioni del nuovo metodo di pagamento o eliminarlo in ogni momento, premendo sulla card corrispondente nel tuo Portafoglio.",
+            "faqs": [
+               {
+                  "title": "Dove trovo il codice di sicurezza?",
+                  "body": "Il codice di sicurezza, chiamato anche CVV o CVS, è un codice a tre cifre che si trova sul retro della tua carta. Sulle carte American Express si chiama CID, è a quattro cifre e si trova sul fronte. Se non lo trovi, probabilmente la tua carta non è abilitata ai pagamenti online."
+               },
+               {
+                  "title": "Non riesco ad aggiungere la mia carta. Come mai?",
+                  "body": "In questo caso, ti consigliamo di contattare la tua banca. I motivi possono essere diversi, i più frequenti sono:\n\n*La tua carta non è abilitata agli acquisti online;\n\n*La tua carta è stata messa “in pausa”;\n\n*Non hai ancora attivato il servizio 3DS, un sistema di sicurezza legato ai pagamenti online.\n\n Alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento/) trovi un elenco dettagliato dei metodi supportati dall’app."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_PRIVATIVE_DETAIL",
+            "title": "La tua carta supermercato",
+            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+            "faqs": [
+               {
+                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+               },
+               {
+                  "title": "Come posso eliminare questo metodo di pagamento?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_BANCOMAT_DETAIL",
+            "title": "La tua carta PagoBANCOMAT",
+            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+            "faqs": [
+               {
+                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+               },
+               {
+                  "title": "Come posso eliminare questo metodo di pagamento?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+               },
+               {
+                  "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+                  "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+               },
+               {
+                  "title": "Perché c'è scritto che la mia carta non è compatibile con i pagamenti in app?",
+                  "body": "Il circuito PagoBANCOMAT non ti consente di effettuare pagamenti online. Se vuoi pagare con la tua carta, puoi: \n\n*Aggiungere al Portafoglio BANCOMAT Pay, se la tua banca offre questo servizio;\n\n*Aggiungere il secondo circuito, se la tua carta ha il codice di sicurezza ed è già abilitata ai pagamenti online."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_PAYPAL_DETAIL",
+            "title": "Il tuo account PayPal",
+            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+            "faqs": [
+               {
+                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+               },
+               {
+                  "title": "Come posso eliminare questo metodo di pagamento?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_CREDIT_CARD_DETAIL",
+            "title": "La tua carta",
+            "content": "In questa pagina puoi vedere i dettagli di questo metodo di pagamento, modificare le impostazioni o eliminarlo dal Portafoglio.",
+            "faqs": [
+               {
+                  "title": "Come posso impostare questo metodo di pagamento come preferito?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Premi sulla card di questo metodo e impostalo come preferito."
+               },
+               {
+                  "title": "Come posso eliminare questo metodo di pagamento?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_HOME",
+            "title": "Cosa puoi fare nel tuo Portafoglio",
+            "content": "Nel Portafoglio trovi i metodi di pagamento che hai aggiunto, i bonus e le iniziative a cui hai aderito e lo storico delle transazioni effettuate con pagoPA, la piattaforma dei pagamenti verso la Pubblica Amministrazione. In questa sezione, puoi anche pagare tutti gli avvisi di pagamento cartacei con il logo pagoPA.",
+            "faqs": [
+               {
+                  "title": "Come posso pagare su IO?",
+                  "body": "Puoi pagare con carte di debito, credito e prepagate o con PayPal. Trovi l'elenco aggiornato dei metodi disponibili alla pagina [metodi di pagamento] (https://io.italia.it/metodi-pagamento)."
+               },
+               {
+                  "title": "Come posso aggiungere un metodo di pagamento?",
+                  "body": "Vai al Portafoglio, premi “Aggiungi” e “Metodo di Pagamento”. Poi, seleziona il metodo che vuoi aggiungere e inserisci i dati richiesti."
+               },
+               {
+                  "title": "Quali bonus, sconti o altre iniziative posso richiedere?",
+                  "body": "Vai al Portafoglio, premi “Aggiungi” e “Sconti, bonus e altre iniziative”. Comparirà una lista con tutti i bonus e le iniziative che puoi richiedere tramite l’app IO."
+               },
+               {
+                  "title": "Non riesco ad aggiungere un metodo di pagamento. Cosa posso fare?",
+                  "body": "Accedi alla pagina [stato aggiunta metodi di pagamento] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), seleziona il tentativo di aggiunta fallito e contatta l’assistenza."
+               },
+               {
+                  "title": "Come posso eliminare un metodo di pagamento?",
+                  "body": "I tuoi metodi di pagamento sono visualizzati come card nella parte alta dello schermo del Portafoglio. Seleziona la card del metodo che vuoi eliminare e poi premi “Elimina questo metodo”."
+               },
+               {
+                  "title": "Ho un problema con un pagamento. Cosa posso fare?",
+                  "body": "Accedi alla pagina [stato dei tuoi pagamenti] (ioit://PAYMENTS_HISTORY_SCREEN), seleziona il tentativo di pagamento fallito e contatta l’assistenza."
+               },
+               {
+                  "title": "Dove trovo i pagamenti che ho effettuato?",
+                  "body": "Nel Portafoglio trovi una lista che contiene i pagamenti effettuati con successo tramite l’app IO. La lista include anche i pagamenti effettuati tramite il sito o l’app degli enti aderenti, se ti sei autenticato con SPID."
+               },
+               {
+                  "title": "Posso pagare un avviso che non ho ricevuto tramite IO?",
+                  "body": "Sì, se sull’avviso sono presenti il logo pagoPA e il codice QR o il Codice Avviso. Per farlo, vai nel Portafoglio, scansiona il QR o inserisci il Codice Avviso e completa il pagamento."
+               },
+               {
+                  "title": "Che cos’è un codice QR?",
+                  "body": "Il codice QR è un’immagine quadrata composta da elementi bianchi e neri. Se inquadrato dalla fotocamera di un telefono permette di accedere a contenuti digitali, come ad esempio un sito web, un pagamento o un articolo.\n\nIl codice QR che trovi sugli avvisi di pagamento è associato a un Codice Avviso. Se vai al tuo Portafoglio, premi su “Paga un avviso” e inquadri il codice con la fotocamera, puoi pagare l’avviso senza dover inserire manualmente informazioni come causale, cifra o codice fiscale."
+               },
+               {
+                  "title": "Che cos’è pagoPA?",
+                  "body": "pagoPA è una piattaforma per rendere più semplici, sicuri e trasparenti tutti i pagamenti verso la Pubblica Amministrazione. Tra i vari benefici, permette di aumentare l’uso di modalità elettroniche di pagamento e rende le persone libere di scegliere come pagare, dando evidenza dei costi di commissione. Per saperne di più, [vai sul sito di pagoPA] (https://www.pagopa.gov.it/)."
+               },
+               {
+                  "title": "Come posso saperne di più sui pagamenti digitali?",
+                  "body": "Per approfondire i temi di tuo interesse legati al mondo dei pagamenti, puoi consultare i materiali messi a disposizione dalla Banca d’Italia nell’ambito dei programmi di Educazione Finanziaria, tra cui la [sezione dedicata] (https://economiapertutti.bancaditalia.it/pagare/) del sito [L’Economia per tutti] (https://economiapertutti.bancaditalia.it/) e la [Guida sui Pagamenti nel Commercio Elettronico] (https://www.bancaditalia.it/pubblicazioni/guide-bi/guida-pagamenti-comm-elettronico/guide-BI-i-pagamenti-nel-commercio-elettronico_ITA.pdf).\n\nPer esempio, se vuoi saperne di più sui metodi di pagamento che puoi aggiungere al Portafoglio dell’app IO, puoi leggere le schede informative dedicate, come [carta di credito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [carta di debito] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [carta prepagata] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [carta co-badge] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) o altri servizi digitali, [come PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+               }
+            ]
+         },
+         {
+            "route_name": "UADONATION_ROUTES_WEBVIEW",
+            "title": "Donazioni Ucraina",
+            "content": "In questa pagina, puoi fare una donazione alle organizzazioni umanitarie che assistono le vittime civili della crisi in Ucraina.",
+            "faqs": [
+               {
+                  "title": "Come posso donare?",
+                  "body": "Per donare, scegli un’organizzazione umanitaria tra quelle che trovi nella lista. Poi, seleziona l’importo che vuoi donare e premi “Continua”. Usa un metodo di pagamento compatibile o selezionalo dal Portafoglio. Infine, premi “Paga” per completare la donazione."
+               },
+               {
+                  "title": "Con che metodi di pagamento posso fare la donazione?",
+                  "body": "Puoi donare con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard e con conto PayPal."
+               },
+               {
+                  "title": "C'è un importo minimo?",
+                  "body": "Sì, puoi donare da un minimo di 5 € a un massimo di 200 €. Se vuoi donare importi superiori, ripeti la donazione."
+               },
+               {
+                  "title": "La donazione prevede dei costi di commissione?",
+                  "body": "Se doni con carta di credito, debito o prepagata del circuito Visa, Maestro o Mastercard non hai costi di commissione."
+               },
+               {
+                  "title": "Dopo la donazione, non ho ricevuto nessuna email con la ricevuta. Cosa posso fare?",
+                  "body": "Dopo la donazione, ti invieremo un'email con la ricevuta. Se non la ricevi, guarda nella cartella spam e verifica che l'indirizzo che trovi nella sezione Profilo > I tuoi dati sia corretto. Ti consigliamo di conservare la ricevuta della donazione, insieme alla documentazione originale del versamento (come l'estratto conto della banca o della carta di credito) per fini fiscali."
+               },
+               {
+                  "title": "Rappresento un'organizzazione umanitaria: posso partecipare all'iniziativa?",
+                  "body": "Per avere informazioni su come partecipare all'iniziativa, scrivi un'email a affari.istituzionali@pagopa.it."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ONBOARDING_PAYPAL_SEARCH_PSP",
+            "title": "Scegli il gestore della transazione",
+            "content": "Il gestore della transazione, ovvero il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore, può applicare ad ogni pagamento una commissione variabile. In questa pagina, puoi scegliere quale gestore della transazione utilizzare. Potrai modificare questa scelta ad ogni pagamento, scegliendo in base alla commissione proposta.",
+            "faqs": [
+               {
+                  "title": "Cos’è il gestore della transazione?",
+                  "body": "Il gestore della transazione, conosciuto anche come PSP (Prestatore di Servizi di Pagamento), è il soggetto che riscuote l’importo dovuto per conto di un Ente Creditore. Per svolgere questo servizio, il gestore può applicare ogni volta una commissione.\n\npagoPA ti permette di effettuare pagamenti elettronici tramite uno dei gestori della transazione aderenti. È questo il tramite che ti permette di pagare un avviso, una retta, un bollo o un tributo direttamente in app."
+               },
+               {
+                  "title": "Perché devo scegliere il gestore della transazione?",
+                  "body": "Quando effettui un pagamento, IO ti mostra tutti i gestori della transazione che puoi utilizzare, così che tu possa scegliere quello che ti conviene di più a seconda della commissione proposta. Ad incassare questa commissione non è pagoPA, ma il gestore stesso."
+               },
+               {
+                  "title": "Quale gestore devo scegliere?",
+                  "body": "Puoi selezionare il gestore che preferisci, che tu sia cliente o no e anche se non lo hai mai utilizzato prima. La scelta del gestore non è definitiva: puoi modificarla ad ogni pagamento."
+               },
+               {
+                  "title": "A cosa è dovuto il costo della transazione?",
+                  "body": "Per sostenere i costi di gestione e garantire la sicurezza del trasferimento di denaro, ogni gestore della transazione può applicare una commissione variabile. La commissione varia a seconda delle politiche commerciali e delle condizioni contrattuali sottoscritte col gestore che hai scelto. IO ti mostrerà sempre il costo della transazione indicato dal gestore della transazione, per permetterti di scegliere quello più conveniente."
+               },
+               {
+                  "title": "Non riesco ad aggiungere PayPal come metodo di pagamento.",
+                  "body": "Se hai dei problemi ad aggiungere il tuo conto PayPal, ti suggeriamo di:\n\n1.Controllare che il tuo dispositivo sia connesso a una rete.\n\n2.Accertarti di aver inserito correttamente username e password del tuo conto PayPal.\n\n3.Assicurarti di avere completato l’autenticazione a due fattori.\n\nSe hai effettuato tutti i passaggi correttamente e non hai ancora risolto il problema contatta l’[assistenza di PayPal](https://www.paypal.com/it/smarthelp/contact-us)."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ONBOARDING_PAYPAL_START",
+            "title": "Paga con PayPal",
+            "content": "In questa pagina potrai aggiungere PayPal come metodo di pagamento nell’app IO.\n\nPayPal ti permette di pagare senza inserire ogni volta i tuoi dati finanziari. Ti permette anche di collegare il tuo conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.",
+            "faqs": [
+               {
+                  "title": "Cos’è PayPal?",
+                  "body": "PayPal è il servizio che ti consente di pagare, inviare denaro e accettare pagamenti in modo più rapido, semplice e sicuro, senza dover immettere ogni volta i tuoi dati finanziari. Per approfondire o aprire un conto gratuitamente, vai sul sito [paypal.com](https://www.paypal.com/it)."
+               },
+               {
+                  "title": "Come funziona?",
+                  "body": "Per utilizzare PayPal su IO, registrati con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it) e collega la tua carta di credito, di debito, prepagata o il conto corrente.\n\nPoi, aggiungilo come metodo di pagamento nella sezione Portafoglio di IO. Per farlo, ti verranno richiesti l’indirizzo email e la password del tuo conto PayPal. Dovrai inoltre completare l’autenticazione a due fattori utilizzando una modalità a scelta tra app PayPal, SMS o chiamata."
+               },
+               {
+                  "title": "Che vantaggi ho ad utilizzare PayPal per pagare tramite IO?",
+                  "body": "PayPal ti permetterà di autorizzare le operazioni di pagamento in modo semplice e veloce, senza che tu debba inserire i tuoi dati finanziari.\n\nPuoi collegare al tuo conto PayPal non solo la carta di credito, di debito o prepagata, ma anche il conto bancario, che risulta utile qualora dovessi pagare importi elevati che superano il massimale della tua carta.\n\n[Scopri qui](https://www.paypal.com/it/smarthelp/article/come-faccio-a-collegare-il-mio-conto-bancario-al-mio-conto-paypal-faq686) come collegare il tuo conto bancario a PayPal."
+               },
+               {
+                  "title": "Non ho un conto PayPal. Come posso crearne uno?",
+                  "body": "Per creare un conto PayPal, devi registrarti con il tuo nome e indirizzo email sul sito [paypal.com](https://www.paypal.com/it). Per farlo, devi essere maggiorenne e collegare almeno un metodo di pagamento."
+               }
+            ]
+         },
+         {
+            "route_name": "MESSAGE_DETAIL",
+            "title": "Dettagli del messaggio",
+            "content": "Qui puoi visualizzare il dettaglio della comunicazione ricevuta da un ente integrato all'app IO. Se hai dubbi o delle domande sul contenuto specifico del messaggio, puoi contattare l'ente utilizzando i recapiti che trovi in fondo a questo messaggio o nella sezione 'Servizi'.",
+            "faqs": [
+               {
+                  "title": "Questo messaggio non ti interessa?",
+                  "body": "Su IO è possibile disattivare la comunicazione dai servizi che non ti interessano in qualsiasi momento: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi)."
+               },
+               {
+                  "title": "C'è un errore nella comunicazione che hai ricevuto?",
+                  "body": "Se pensi che ci sia un errore nel messaggio che hai ricevuto, puoi utilizzare i recapiti di contatto dell'ente erogatore del servizio per fare una segnalazione o chiedere chiarimenti. \nI recapiti sono disponibili dall'area dettagli del messaggio oppure nella sezione 'Servizi' dell'app IO, selezionando lo specifico ente e servizio in questione. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
+               },
+               {
+                  "title": "Questo ente ha il permesso di scriverti?",
+                  "body": "Un ente può inviarti dei messaggi solo se ha una comunicazione specifica da recapitare a te, associata al tuo codice fiscale. Il tuo codice fiscale non viene comunicato dall'app IO all'ente, ma ciascun ente può utilizzare l'app IO per scriverti solo se ha già i tuoi dati (e quindi una relazione con te). \n \nSe non vuoi più ricevere comunicazioni da uno specifico ente, puoi disattivarne i servizi che non ti interessano: \n1. visita la sezione Servizi; \n2. seleziona il servizio in questione dalla lista; \n3. nell'area 'Questo servizio può' disabilita l'opzione 'Contattarti in app'. \n \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nNella sezione 'Profilo > Preferenze > Gestione servizi' puoi decidere di lasciare accesa la comunicazione di tutti i servizi, oppure scegliere la configurazione manuale per cui dovrai configurare a uno a uno tutti i servizi dalla relativa schermata di dettaglio."
+               },
+               {
+                  "title": "Vuoi contattare l'ente?",
+                  "body": "Dai dettagli del messaggio puoi visualizzare le informazioni relative allo specifico servizio e ente erogatore. Se segui il link al profilo del servizio trovi le informazioni estese, e i recapiti attraverso i quali puoi contattare l'ente erogatore del servizio. \nA seconda delle modalità di contatto gestite dal singolo ente e servizio, i recapiti possono includere: indirizzo dello sportello fisico, numero di telefono, indirizzo mail e/o PEC, sito web, assistenza online, mobile app. "
+               }
+            ]
+         },
+         {
+            "route_name": "SERVICES_HOME",
+            "title": "Cosa puoi fare nei tuoi Servizi",
+            "content": "Qui puoi visualizzare la lista dei servizi nazionali o locali disponibili su IO. \nPremi sul nome di un servizio per visualizzarne i dettagli.",
+            "faqs": [
+               {
+                  "title": "Come gestire i servizi su IO?",
+                  "body": "Utilizza le configurazioni disponibili nella sezione 'Profilo > Preferenze > Gestione servizi', oppure le opzioni contenute nel dettaglio di ciascun servizio per decidere come riceverne le comunicazioni (messaggio in app, notifica push, inoltro del messaggio via e-mail). \n \nAttenzione! Vedere la lista completa dei servizi non significa che ti contatteranno servizi che non ti riguardano: gli enti comunicano con te solo se in possesso del tuo codice fiscale e nel momento in cui hanno necessità di inviarti comunicazioni importanti."
+               },
+               {
+                  "title": "Puoi contattare gli enti tramite IO?",
+                  "body": "Non puoi direttamente contattare gli enti dall'app IO ma puoi visualizzare le loro informazioni di contatto all'interno della sezione 'Servizi', nella scheda di ciascun servizio."
+               }
+            ]
+         },
+         {
+            "route_name": "SERVICE_DETAIL",
+            "title": "Dettagli del Servizio",
+            "content": "In questa schermata puoi visualizzare la descrizione del servizio, l'informativa privacy e condizioni d'uso, i dati di contatto dell'ente o del servizio e puoi configurare le modalità di comunicazione per questo specifico servizio. \n \nRicorda che su IO ti scriveranno solo servizi che hanno qualche informazione personalizzata da comunicarti: non riceverai messaggi di spam o contenuti che non ti riguardano direttamente. \n \nSe vuoi comunque impedire al servizio di contattarti puoi farlo nell'area 'Questo servizio può', disabilitando l'opzione 'Contattarti in app'. \nL'ente non ti scriverà più tramite IO, ma potrà comunque contattarti tramite i consueti canali di comunicazione in uso (email, telefono o posta a seconda dei casi). \n \nDa questa pagina puoi inoltre gestire l'invio di notifiche push e l'inoltro dei messaggi anche al tuo indirizzo e-mail.",
+            "faqs": [
+               {
+                  "title": "Cosa succede se disattivi un servizio?",
+                  "body": "Non riceverai più le comunicazioni di quello specifico servizio nell'app IO. L'ente che eroga il servizio potrà comunque contattarti o essere contattato attraverso altri canali quali sito, email, numero di telefono o ufficio di pertinenza."
+               },
+               {
+                  "title": "Come funzionano le notifiche push?",
+                  "body": "Le notifiche push ti informano che è arrivato un nuovo messaggio nell'app IO, e ti invitano a procedere alla lettura. \n \nSe preferisci disattivarle, disabilita nell'area 'Questo servizio può' l'opzione 'Inviarti notifiche push'. Nella sezione Messaggi potrai comunque distinguere i messaggi non letti grazie al pallino blu."
+               },
+               {
+                  "title": "Come funziona l'inoltro via email dei messaggi?",
+                  "body": "Attivando l'inoltro via email dei messaggi, riceverai all'indirizzo email associato all'app una copia del messaggio che ricevi su IO. \nL'inoltro via mail non è disponibile per alcuni servizi, sulla base di decisioni prese dall'ente in merito alla sensibilità dei contenuti del messaggio stesso."
+               }
+            ]
+         },
+         {
+            "route_name": "PROFILE_PREFERENCES_EMAIL_FORWARDING",
+            "title": "Come gestire l'inoltro dei messaggi",
+            "content": "Qui puoi abilitare o disabilitare l'inoltro al tuo indirizzo e-mail dei messaggi che ricevi su IO."
+         },
+         {
+            "route_name": "PROFILE_PREFERENCES_SERVICES",
+            "title": "Gestisci servizi in app",
+            "content": "Qui puoi decidere come gestire la comunicazione dei servizi. \nL'app IO vuole essere un canale di comunicazione aggiuntivo per gli enti nazionali o locali che hanno qualcosa da dire proprio a te. \nNon manda messaggi broadcast o spam e per questo ti consigliamo di utilizzare la configurazione rapida, mantenendo la comunicazione dei servizi sempre attiva.",
+            "faqs": [
+               {
+                  "title": "Perché dovrei usare la configurazione rapida?",
+                  "body": "Perchè IO manda solo messaggi utili e rivolti proprio a te: gli enti erogatori dei servizi devono conoscere il tuo codice fiscale per poterti scrivere e questo è garanzia del fatto che hanno già una relazione con te. Usando la configurazione rapida non devi pensare a niente e riceverai i messaggi che ti riguardano anche dai servizi che arriveranno in futuro. \nSe decidi comunque di usare la configurazione manuale, sappi che gli enti potranno contattarti attraverso i canali tradizionali a loro disposizione."
+               },
+               {
+                  "title": "Cosa succede se utilizzo la configurazione manuale?",
+                  "body": "La configurazione manuale spegne la comunicazione di tutti i servizi, quelli attualmente presenti e quelli che arriveranno in futuro. \nPer ricevere i messaggi dai servizi che ti interessano dovrai configurarli uno a uno dalle relative schede servizio. \nAttenzione! Spegnendo la comunicazione tramite IO, l'ente che eroga il servizio potrà comunque contattarti attraverso i canali tradizionali disponibili (es. e-mail, posta, SMS)."
+               }
+            ]
+         },
          {
             "route_name": "EUCOVIDCERT_CERTIFICATE",
             "title": "La tua Certificazione Verde COVID-19",
@@ -722,500 +724,504 @@
                   "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
                   "body": "Probabilmente la tua carta PagoBANCOMAT è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
                },
-         {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
-            "title": "Vuoi iscriverti al programma Cashback?",
-            "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
-            "faqs": [
                {
-                  "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
-                  "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
+                  "route_name": "WALLET_ONBOARDING_BANCOMAT_SUGGEST_BPD_ACTIVATION",
+                  "title": "Vuoi iscriverti al programma Cashback?",
+                  "content": "Se stai visualizzando questa schermata, significa che hai appena aggiunto metodi di pagamento compatibili con l'iniziativa Cashback.\nSe vuoi iscriverti per provare a ottenere un rimborso sui tuoi acquisti effettuati con strumenti di pagamento elettronico, premi su **Info e Attivazione**, altrimenti premi **No, grazie.**",
+                  "faqs": [
+                     {
+                        "title": "Quali metodi di pagamento posso usare per partecipare al Cashback?",
+                        "body": "Puoi partecipare al Cashback con:\n- carte di credito;\n-carte di debito su circuiti internazionali e su circuito PagoBANCOMAT;\n- carte prepagate;\n- le cosiddette carte fedeltà, ovvero carte e app di pagamento connesse a circuiti privativi e/o a spendibilità limitata (esclusi, quindi, quelli solo per accumulo punti);\n- app di pagamento, come ad esempio Satispay o BANCOMAT Pay;\n- altri sistemi di pagamento, come ad esempio Google Pay e Apple Pay (a partire dal 2021)."
+                     },
+                     {
+                        "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
+                        "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
+                     }
+                  ]
                },
                {
-                  "title": "Posso cancellarmi dal Cashback in qualsiasi momento?",
-                  "body": "Sì. Se ti sei iscritto al programma tramite app IO, puoi sempre recedere cliccando su 'Cancella la tua iscrizione al Cashback' dalla schermata di dettaglio Cashback nella sezione 'Portafoglio'.\nSe invece per iscriverti hai usato uno di uno degli [Issuer Convenzionati](https://io.italia.it/cashback/issuer), puoi cancellarti  solo se non hai attivi altri metodi di pagamento su altri canali."
+                  "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
+                  "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
+                  "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+                  "faqs": [
+                     {
+                        "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+                        "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+                     },
+                     {
+                        "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+                        "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+                     },
+                     {
+                        "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+                        "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+                     },
+                     {
+                        "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+                        "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+                     }
+                  ]
+               },
+               {
+                  "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
+                  "title": "Attiva il Cashback sulle tue carte",
+                  "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
+                  "faqs": [
+                     {
+                        "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
+                        "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+                     },
+                     {
+                        "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
+                        "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+                     },
+                     {
+                        "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
+                        "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+                     },
+                     {
+                        "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
+                        "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+                     }
+                  ]
+               },
+               {
+                  "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
+                  "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+                  "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
+                  "faqs": [
+                     {
+                        "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
+                        "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
+                     },
+                     {
+                        "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
+                        "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
+                     },
+                     {
+                        "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+                        "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+                     }
+                  ]
+               },
+               {
+                  "route_name": "WALLET_ONBOARDING_COBADGE_START",
+                  "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+                  "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
+                  "faqs": [
+                     {
+                        "title": "Posso aggiungere anche carte con circuito internazionale?",
+                        "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
+                     },
+                     {
+                        "title": "Perché non trovo alcuna carta?",
+                        "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
+                     }
+                  ]
+               },
+               {
+                  "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
+                  "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
+                  "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
+                  "faqs": [
+                     {
+                        "title": "Perché la data di scadenza è diversa?",
+                        "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+                     },
+                     {
+                        "title": "Perché il numero della carta è diverso?",
+                        "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+                     },
+                     {
+                        "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
+                        "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
+                     }
+                  ]
+               },
+               {
+                  "route_name": "WALLET_COBADGE_DETAIL",
+                  "title": "La tua carta con circuito internazionale",
+                  "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
+                  "faqs": [
+                     {
+                        "title": "Cosa posso fare da qui?",
+                        "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
+                     },
+                     {
+                        "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
+                        "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
+                     },
+                     {
+                        "title": "Perché la data di scadenza è diversa?",
+                        "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
+                     },
+                     {
+                        "title": "Perché il numero della carta è diverso?",
+                        "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
+                     }
+                  ]
+               },
+               {
+                  "route_name": "AUTHENTICATION_LANDING",
+                  "title": "Come accedere all'app IO",
+                  "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
+                  "faqs": [
+                     {
+                        "title": "Cos'è SPID?",
+                        "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
+                     },
+                     {
+                        "title": "Come puoi ottenere SPID?",
+                        "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
+                     },
+                     {
+                        "title": "Hai perso le tue credenziali SPID?",
+                        "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
+                     },
+                     {
+                        "title": "Cos'è la CIE?",
+                        "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
+                     },
+                     {
+                        "title": "Come puoi ottenere la CIE?",
+                        "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
+                     },
+                     {
+                        "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+                        "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+                     },
+                     {
+                        "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+                        "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Posso ricevere su IO i certificati dei miei familiari?",
+                        "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
+                        "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
+                     },
+                     {
+                        "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+                        "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+                        "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
+                        "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
+                     },
+                     {
+                        "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+                        "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Usi Android e non riesci ad aggiornare IO?",
+                        "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+                     }
+                  ]
+               },
+               {
+                  "route_name": "MESSAGES_HOME",
+                  "title": "Cosa puoi fare nei tuoi Messaggi",
+                  "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
+                  "faqs": [
+                     {
+                        "title": "Che tipo di messaggi posso ricevere?",
+                        "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
+                     },
+                     {
+                        "title": "Cosa succede se archivio i messaggi?",
+                        "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
+                     },
+                     {
+                        "title": "I messaggi possono essere cancellati?",
+                        "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
+                     },
+                     {
+                        "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
+                        "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
+                     },
+                     {
+                        "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
+                        "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Posso ricevere su IO i certificati dei miei familiari?",
+                        "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
+                        "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+                     },
+                     {
+                        "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
+                        "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
+                     },
+                     {
+                        "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
+                        "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
+                        "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
+                        "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
+                        "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
+                     },
+                     {
+                        "title": "Usi Android e non riesci ad aggiornare IO?",
+                        "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
+                     }
+                  ]
                }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_BANCOMAT_ACTIVATE_BPD_NEW",
-            "title": "Attiva il Cashback sulle tue carte PagoBANCOMAT",
-            "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-            "faqs": [
-               {
-                  "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                  "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+            ],
+            "idps": {
+               "arubaid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
+                  "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
+                  "phone": "003905750504",
+                  "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
+                  "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
+                  "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
+                  "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
                },
-               {
-                  "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                  "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
+               "infocertid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
+                  "helpdesk_form": "https://contatta.infocert.it/ticket/",
+                  "phone": "00390654641489",
+                  "web_site": "https://identitadigitale.infocert.it/",
+                  "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
+                  "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
                },
-               {
-                  "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                  "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
+               "intesaid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
+                  "email": "hdintesa@advalia.com",
+                  "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
+                  "phone": "800805093",
+                  "phone_international": "00390287119396",
+                  "web_site": "https://www.intesa.it/intesaid",
+                  "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
                },
-               {
-                  "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                  "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
+               "lepidaid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
+                  "email": "helpdesk@lepida.it",
+                  "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
+                  "phone": "800445500",
+                  "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
+                  "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
+                  "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
+               },
+               "namirialid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
+                  "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
+                  "phone": "003907163494",
+                  "web_site": "https://www.namirialtsp.com/spid/",
+                  "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
+                  "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
+               },
+               "posteid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
+                  "helpdesk_form": "https://www.poste.it/scrivici.html",
+                  "phone": "800007777",
+                  "web_site": "https://posteid.poste.it",
+                  "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
+                  "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
+               },
+               "sielteid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
+                  "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
+                  "phone": "00390957171301",
+                  "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
+                  "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
+               },
+               "spiditalia": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
+                  "phone": "+390355787979",
+                  "web_site": "https://www.register.it/spid/ ",
+                  "recover_username": "https://spid.register.it/selfcare/recovery/username ",
+                  "recover_password": "https://spid.register.it/selfcare/recovery/password"
+               },
+               "timid": {
+                  "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
+                  "email": "supportotimid@telecomitalia.it",
+                  "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
+                  "phone": "800405800",
+                  "web_site": "https://spid.tim.it/tim-id-portal",
+                  "recover_username": "https://login.id.tim.it/mps/fu.php",
+                  "recover_password": "https://login.id.tim.it/mps/fp.php"
                }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_CREDIT_CARD_ACTIVATE_BPD_NEW",
-            "title": "Attiva il Cashback sulle tue carte",
-            "content": "In questa schermata ti chiediamo di abilitare i metodi di pagamento appena aggiunti per il Cashback.\nUna volta attivi, potrai iniziare a collezionare transazioni valide a partire dal giorno successivo alla data di attivazione.\n\nPer attivare i metodi, devi semplicemente premere sull'icona grigia alla destra dell'elemento. Se l'icona diventa blu, allora il metodo selezionato è attivo.",
-            "faqs": [
-               {
-                  "title": "Dopo aver aderito al Cashback, posso aggiungere nuovi metodi di pagamento (o eliminarne alcuni) in qualsiasi momento?",
-                  "body": "Sì, per tutta la durata del programma, è sempre possibile attivare metodi di pagamento aggiuntivi (o disattivare quelli utilizzati fino a un determinato periodo) per il Cashback. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-               },
-               {
-                  "title": "Quanti metodi di pagamento elettronico posso attivare per il Cashback?",
-                  "body": "Non c’è un limite: puoi attivare tutti i tuoi metodi di pagamento elettronici, che siano registrabili per partecipare al programma, e utilizzarli per acquisti personali, fuori dall’attività professionale. [Verifica quali metodi di pagamento puoi già attivare](https://io.italia.it/metodi-pagamento)"
-               },
-               {
-                  "title": "Posso partecipare al Cashback anche con una carta intestata a un'altra persona?",
-                  "body": "Devi essere tu il titolare dei metodi di pagamento elettronico su cui attivi il Cashback. Inoltre, anche nel caso in cui lo stesso metodo di pagamento sia cointestato, solo uno dei titolari può concorrere al programma con quello strumento."
-               },
-               {
-                  "title": "Ho appena registrato la mia carta al Cashback sull’app IO, posso fare da subito acquisti validi ai fini del programma?",
-                  "body": "No, saranno conteggiati come validi per il Cashback gli acquisti effettuati con il metodo di pagamento che hai attivato, a partire dalle ore 00:01 del giorno seguente all’attivazione."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
-            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-            "content": "Per aggiungere correttamente il circuito internazionale associato alla tua carta PagoBANCOMAT, ci serve sapere se hai mai utilizzato questa carta online, così da indirizzarti verso la pagina più adatta al tuo caso.",
-            "faqs": [
-               {
-                  "title": "Come faccio a capire se la mia carta è abilitata ai pagamenti online?",
-                  "body": "La tua carta deve avere un codice di sicurezza: è di 3 cifre ed è stampato sul retro. Se non lo trovi, significa che puoi utilizzare la tua carta soltanto nei negozi.\n\nAssicurati inoltre di aver abilitato il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa). Per maggiori informazioni, accedi al tuo Home Banking o contatta la tua banca."
-               },
-               {
-                  "title": "La mia carta ha il codice di sicurezza, ma non riesco comunque a salvarla in app.",
-                  "body": "Dopo aver inserito i dati della tua carta, la tua banca effettua una verifica, solitamente via SMS o con una notifica tramite la propria app. Segui bene le istruzioni mostrate dalla tua banca e, in caso di problemi, contatta il loro servizio clienti.\n\nSe non ricevi alcun messaggio (oppure la transazione viene negata) significa che la tua carta non è abilitata ai pagamenti online. Rivolgiti alla tua banca e chiedi come attivare il servizio 3D Secure (Mastercard Identity Check per le carte Mastercard) e Verified By Visa/Visa Secure (per le carte Visa)."
-               },
-               {
-                  "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-                  "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_COBADGE_START",
-            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-            "content": "Questo servizio ti permette di cercare tutte le carte con circuito internazionale (Maestro, Mastercard, Visa e V-Pay) a te intestate.",
-            "faqs": [
-              {
-                  "title": "Posso aggiungere anche carte con circuito internazionale?",
-                  "body": "Sì, puoi aggiungere anche carte di debito o credito con circuito internazionale (Maestro, Mastercard, VISA e V-Pay), anche se non sono abilitate ai pagamenti online. Le carte devono essere intestate a te ed emesse dalle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online) al servizio."
-               },
-               {
-                  "title": "Perché non trovo alcuna carta?",
-                  "body": "Il servizio cerca solo carte con circuito internazionale intestate a te. Assicurati che la carta in tuo possesso sia effettivamente intestata a te e che sia emessa da una delle [banche aderenti](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)"
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
-            "title": "Aggiungi il secondo circuito della tua carta PagoBANCOMAT",
-            "content": "In questa pagina vengono mostrate tutte le carte intestate a te, su circuito internazionale (Maestro, Mastercard, Visa e V-Pay) presso le banche aderenti al servizio. Se non desideri aggiungere una delle carte mostrate, premi 'Salta' per passare a quella successiva.",
-            "faqs": [
-               {
-                  "title": "Perché la data di scadenza è diversa?",
-                  "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-               },
-               {
-                  "title": "Perché il numero della carta è diverso?",
-                  "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-               },
-               {
-                  "title": "Ho già aggiunto il secondo circuito, cosa devo fare?",
-                  "body": "Se hai già aggiunto al Portafoglio il circuito internazionale come 'carta di debito/credito', non è necessario aggiungere nuovamente la carta tramite questa funzionalità."
-               }
-            ]
-         },
-         {
-            "route_name": "WALLET_COBADGE_DETAIL",
-            "title": "La tua carta con circuito internazionale",
-            "content": "Questa è la schermata di dettaglio della tua carta con circuito internazionale. Sulla carta sono rappresentati il logo della banca che ha emesso la carta, la data di scadenza e logo e numero relativi al circuito internazionale.",
-            "faqs": [
-               {
-                  "title": "Cosa posso fare da qui?",
-                  "body": "Puoi attivare o disattivare alcune funzioni sullo specifico metodo di pagamento.\nPuoi inoltre eliminare questo metodo di pagamento dal tuo Portafoglio."
-               },
-               {
-                  "title": "Perché il nome e il logo della banca sono diversi da quelli riportati sulla mia carta?",
-                  "body": "Probabilmente la tua carta è stata emessa da una banca differente. Questo succede soprattutto per le banche online o in caso di incorporazioni."
-               },
-               {
-                  "title": "Perché la data di scadenza è diversa?",
-                  "body": "In alcuni casi, la data di scadenza mostrata in app può essere diversa rispetto a quella stampata sulla carta fisica, ma ciò non inficia l'aggiunta."
-               },
-               {
-                  "title": "Perché il numero della carta è diverso?",
-                  "body": "IO ti mostra le ultime 4 cifre relative al circuito internazionale. Tale numero viene riportato anche sugli scontrini, quando effettui acquisti usando tale circuito. In alcuni casi, la carta potrebbe invece mostrare un numero differente, ma ciò non inficia l'aggiunta."
-               },
-            ]
-         },
-         {
-            "route_name": "AUTHENTICATION_LANDING",
-            "title": "Come accedere all'app IO",
-            "content": "Per accedere all'app IO dovrai autenticarti con la tua identità SPID (Sistema Pubblico di Identità Digitale) oppure utilizzando la CIE (Carta d'Identità Elettronica).\n**Grazie a questi sistemi di registrazione il tuo accesso all'app sarà sempre sicuro.** \nPer richiedere un'identità digitale SPID puoi visitare [spid.gov.it](https://www.spid.gov.it) e scegliere un Identity Provider tra quelli proposti.\nSe invece desideri fare richiesta per la CIE, puoi consultare maggiori informazioni sul sito del tuo Comune e prenotare un appuntamento.",
-            "faqs": [
-               {
-                  "title": "Cos'è SPID?",
-                  "body": "SPID è il sistema di autenticazione che permette a cittadini ed imprese di accedere ai servizi online della pubblica amministrazione e dei privati aderenti con un’identità digitale unica. L’identità SPID è costituita da credenziali (nome utente e password) che vengono rilasciate all’utente e che permettono l’accesso a tutti i servizi online."
-               },
-               {
-                  "title": "Come puoi ottenere SPID?",
-                  "body": "Per ottenere le tue credenziali SPID devi rivolgerti a Aruba, Infocert, Intesa, Namirial, Poste, Register, Sielte, Tim o Lepida. Questi soggetti (detti Identity Provider) ti offrono diverse modalità per richiedere e ottenere SPID, puoi scegliere quella più adatta alle tue esigenze. Tutte le informazioni su dove e come chiedere le tue credenziali SPID sul sito [https://www.spid.gov.it/cos-e-spid/come-attivare-spid/](https://www.spid.gov.it/cos-e-spid/come-attivare-spid/)."
-               },
-               {
-                  "title": "Hai perso le tue credenziali SPID?",
-                  "body": "Non ti preoccupare, è sempre possibile recuperare le tue credenziali.\n- Se hai richiesto SPID a **Aruba** segui la procedura di recupero qui: [https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx](https://guide.pec.it/spid/recupero-dati/procedure-di-recupero-dati-smarriti.aspx)\n- Se hai richiesto SPID a **Infocert** segui la procedura di recupero qui: [https://my.infocert.it/selfcare/#/recoveryPin](https://my.infocert.it/selfcare/#/recoveryPin)\n- Se hai richiesto SPID a **Namirial** segui la procedura di recupero qui: [https://portale.namirialtsp.com/private/user/spid_reset.php](https://portale.namirialtsp.com/private/user/spid_reset.php)\n- Se hai richiesto SPID a **Intesa** segui la procedura di recupero qui: [https://spid.intesa.it/area-privata/forgot-password.aspx](https://spid.intesa.it/area-privata/forgot-password.aspx)\n- Se hai richiesto SPID a **Poste** segui la procedura di recupero qui: [https://posteid.poste.it/recuperocredenziali.shtml](https://posteid.poste.it/recuperocredenziali.shtml)\n- Se hai richiesto SPID a **Register** segui la procedura di recupero qui:\n(username dimenticata) [https://spid.register.it/selfcare/recovery/username](https://spid.register.it/selfcare/recovery/username)\n(password dimenticata) [https://spid.register.it/selfcare/recovery/password](https://spid.register.it/selfcare/recovery/password)\n- Se hai richiesto SPID a **Sielte** segui la procedura di recupero qui:\n(password dimenticata) [https://myid.sieltecloud.it/profile/recovery/forgotPassword](https://myid.sieltecloud.it/profile/recovery/forgotPassword)\n- Se hai richiesto SPID a **Tim** segui la procedura di recupero qui:\n(username dimenticata) [https://login.id.tim.it/mps/fu.php](https://login.id.tim.it/mps/fu.php)\n(password dimenticata) [https://login.id.tim.it/mps/fp.php](https://login.id.tim.it/mps/fp.php)\n- Se hai richiesto SPID a **Lepida** segui la procedura di recupero qui: [https://id.lepida.it/idm/app/recupero_credenziali.jsp](https://id.lepida.it/idm/app/recupero_credenziali.jsp)"
-               },
-               {
-                  "title": "Cos'è la CIE?",
-                  "body": "La CIE, la Carta d’Identità Elettronica, è un documento elettronico altamente sicuro, dotato di un microprocessore a radiofrequenza che ne permette l’utilizzo in svariati scenari, incluso l’accesso a servizi online. Risponde alle esigenze di sicurezza del nostro Paese e sostituisce la versione cartacea."
-               },
-               {
-                  "title": "Come puoi ottenere la CIE?",
-                  "body": "Puoi collegarti all’indirizzo [https://www.prenotazionicie.interno.gov.it/](https://www.prenotazionicie.interno.gov.it) e digitare il nome del tuo Comune, per verificare se utilizza il sistema di appuntamenti online Agenda CIE. In caso positivo, puoi procedere alla prenotazione dell'appuntamento direttamente dal sito, senza nessun login. In alternativa, puoi chiedere un appuntamento sempre online sul sito del tuo Comune, oppure recandoti ad uno degli uffici comunali."
-               },
-               {
-                  "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-                  "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-               },
-               {
-                  "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-                  "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                  "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Posso ricevere il certificato su IO anche se sono minorenne?",
-                  "body": "Sì, per ricevere i tuoi certificati accedi a IO con la tua Carta d'Identità Elettronica."
-               },
-               {
-                  "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-                  "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-                  "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Posso ricevere su IO la Certificazione di esenzione dalla vaccinazione anti-COVID-19?",
-                  "body": "Sì, puoi ricevere e visualizzare il tuo Certificato di esenzione direttamente in app.\n Questa certificazione è valida solo in Italia fino alla data indicata sulla certificazione e può essere utilizzata per accedere dove è richiesta una Certificazione Verde COVID-19.\n Per maggiori informazioni sulla Certificazione di esenzione dalla vaccinazione anti-COVID-19, consulta le FAQ dedicate [https://www.dgc.gov.it/web/esenzione.html](https://www.dgc.gov.it/web/esenzione.html)."
-               },
-               {
-                   "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                   "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                   "title": "Usi Android e non riesci ad aggiornare IO?",
-                   "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-               }
-            ]
-         },
-         {
-            "route_name": "MESSAGES_HOME",
-            "title": "Cosa puoi fare nei tuoi Messaggi",
-            "content": "**La sezione Messaggi raccoglie tutte le comunicazioni in arrivo dagli enti che offrono i propri servizi tramite IO**.\nÈ possibile fissare dei promemoria per le scadenze o procedere al pagamento di un avviso direttamente dal messaggio.\nI messaggi sono suddivisi tra **ricevuti** (che contiene tutti i messaggi arrivati e non archiviati), **scadenze** (che visualizza al suo interno solo i messaggi contenenti una data di scadenza, in modo da facilitare la gestione delle cose da fare), e **archiviati** (che tiene traccia di tutti i messaggi archiviati).\nPer archiviare un messaggio è sufficiente tenere premuta l'area del messaggio da archiviare, e selezionare il pulsante 'archivia' che comparirà in quel momento sullo schermo.",
-            "faqs": [
-               {
-                  "title": "Che tipo di messaggi posso ricevere?",
-                  "body": "L'app IO permette di ricevere diversi tipi di messaggi: avvisi di pagamento (con possibilità di pagare contestualmente tramite l’app), promemoria di scadenze, notifiche e aggiornamenti vari.\nNon si tratta di messaggi generici che riguardando l'attività dell'ente, ma di comunicazioni che ti riguardano personalmente, come ad esempio un messaggio che ti avvisa della scadenza di un documento. Non aspettarti di ricevere spam sull'app IO: ti scriveranno solo i servizi che hanno qualcosa di importante da dirti."
-               },
-               {
-                  "title": "Cosa succede se archivio i messaggi?",
-                  "body": "I messaggi archiviati vengono spostati nella tab 'Archiviati' della sezione messaggi.\nQuesta modifica ha effetto solo sul telefono che stai utilizzando per effettuare l'operazione di archiviazione: se effettuerai l'accesso con le stesse credenziali su un altro dispositivo, ritroverai tutti i messaggi all'interno della categoria 'Ricevuti'. Puoi comunque rimuovere i messaggi dall'archivio e li ritroverai automaticamente nella tab principale 'Messaggi'."
-               },
-               {
-                  "title": "I messaggi possono essere cancellati?",
-                  "body": "No, i messaggi ricevuti non possono essere cancellati dall'app.\nPer questo abbiamo creato la sezione ‘*Archiviati*’, dove puoi spostare i messaggi che non vuoi più vedere tra quelli ricevuti. In questo modo, se in futuro avrai bisogno di trovare informazioni contenute in un vecchio messaggio, puoi cercare direttamente nella scheda ‘*Archiviati*’."
-               },
-               {
-                  "title": "Come funziona il Certificato Verde COVID-19 (Green Pass) su IO?",
-                  "body": "Il Certificato Verde COVID-19 viene rilasciato dalla Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute e certifica l'avvenuta vaccinazione, un test negativo o la guarigione dalla malattia.\nRiceverai su IO i tuoi certificati non appena verranno generati, sotto forma di messaggio in app. Non dovrai fare nessuna richiesta esplicita: basta aver fatto accesso a IO con SPID o CIE.\nPer saperne di più sul Certificato Verde COVID-19 visita il sito dedicato [dgc.gov.it](https://www.dgc.gov.it/). Per altre informazioni sul certificato su IO visita la [pagina dedicata su io.italia.it](https://io.italia.it/certificato-verde-green-pass-covid)"
-               },
-               {
-                  "title": "Quando riceverò il Certificato Verde COVID-19 su IO?",
-                  "body": "Il Certificato Verde COVID-19 viene inviato tramite IO non appena la Piattaforma Nazionale DGC di cui è titolare il Ministero della Salute lo genera. I tempi di generazione del certificato dipendono da diversi fattori, compresa la velocità con cui le varie strutture sanitarie inviano i dati alla Piattaforma Nazionale.\nDalla partenza dell'iniziativa potrebbe essere necessario qualche giorno per ricevere tutti i certificati. Per saperne di più visita [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Posso ricevere su IO i certificati dei miei familiari?",
-                  "body": "No, su IO vengono inviati esclusivamente i certificati relativi all'utente autenticato nell'app attraverso le proprie credenziali SPID o CIE. Puoi comunque ottenere i certificati relativi ai tuoi familiari attraverso gli altri canali disponibili. Per saperne di più vai su [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Ho appena fatto il vaccino, perché non trovo il mio certificato su IO?",
-                  "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-               },
-               {
-                  "title": "Ho appena fatto un tampone, perché non trovo il mio certificato su IO?",
-                  "body": "Il sistema sanitario impiega del tempo per inviare i dati relativi alla tua vaccinazione alla Piattaforma Nazionale DGC che genera i certificati, e serve ulteriore tempo per generare il grande numero di certificati necessari ogni giorno. Non temere, riceverai su IO un messaggio appena il tuo certificato sarà disponibile tramite l'app."
-               },
-               {
-                  "title": "IO è l'unico canale attraverso cui ottenere il Certificato Verde COVID-19?",
-                  "body": "No. Puoi consultare tutti i canali disponibili sul sito dedicato [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Ho ricevuto tramite sms/mail il CUN (Codice Univoco Nazionale), dove va inserito?",
-                  "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice CUN sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                  "title": "Ho ricevuto tramite sms/mail il codice AUTHCODE per acquisire il Certificato, ma non vedo ancora nessun messaggio su IO. Cosa devo fare?",
-                  "body": "Sull'app IO non devi inserire alcun codice: riceverai un messaggio non appena il tuo Certificato Verde sarà disponibile.\nPuoi utilizzare il codice AUTHCODE sugli altri canali; per saperne di più visita il sito [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                   "title": "Vuoi saperne di più sulla Certificazione Verde COVID-19?",
-                   "body": "Per la Certificazione Verde su IO app, vai su [io.italia.it/certificato-verde-green-pass-covid](https://io.italia.it/certificato-verde-green-pass-covid) \nPer conoscere meglio l’iniziativa o gli altri canali disponibili visita [dgc.gov.it](https://www.dgc.gov.it/)"
-               },
-               {
-                   "title": "Usi Android e non riesci ad aggiornare IO?",
-                   "body": "Per provare a risolvere il problema, ti consigliamo di chiudere l'app 'Play Store' e successivamente premere questo link: https://play.google.com/store/apps/details?id=it.pagopa.io.app \nIn alternativa, riavvia il tuo dispositivo Android e [aggiorna nuovamente app IO dal Play Store](https://play.google.com/store/apps/details?id=it.pagopa.io.app)"
-               }
-            ]
+            }
          }
-      ],
-      "idps": {
-         "arubaid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Aruba selezionando una delle opzioni disponibili qui.",
-            "helpdesk_form": "https://selfcarespid.aruba.it/#/recovery-emergency-code",
-            "phone": "003905750504",
-            "web_site": "https://www.pec.it/richiedi-spid-aruba-id.aspx",
-            "recover_username": "https://selfcarespid.aruba.it/#/recovery-username",
-            "recover_password": "https://selfcarespid.aruba.it/#/recovery-password",
-            "recover_emergency_code": "https://selfcarespid.aruba.it/#/recovery-emergency-code"
-         },
-         "infocertid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da InfoCert  selezionando una delle opzioni disponibili qui di seguito. \n Inoltre, per ulteriori informazioni puoi consultare la [le FAQ e le guide](https://help.infocert.it/Cerca?searchText=spid) fornite dal tuo Identity Provider.",
-            "helpdesk_form": "https://contatta.infocert.it/ticket/",
-            "phone": "00390654641489",
-            "web_site": "https://identitadigitale.infocert.it/",
-            "recover_username": "https://help.infocert.it/home/faq/come-posso-recuperare-la-user-id-di-accesso-alla-mia-identita-digitale",
-            "recover_password": "https://my.infocert.it/selfcare/#/recoveryPin"
-         },
-         "intesaid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Intesa  selezionando una delle opzioni disponibili qui di seguito.",
-            "email": "hdintesa@advalia.com",
-            "helpdesk_form": "https://www.hda.intesa.it/area-clienti",
-            "phone": "800805093",
-            "phone_international": "00390287119396",
-            "web_site": "https://www.intesa.it/intesaid",
-            "recover_password": "https://spid.intesa.it/area-privata/recupera-password.aspx"
-         },
-         "lepidaid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Lepida selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://id.lepida.it/docs/manuale_utente.pdf) fornito da tuo Identity Provider.",
-            "email": "helpdesk@lepida.it",
-            "helpdesk_form": "https://www.lepida.net/assistenza/richiesta-assistenza-lepidaid",
-            "phone": "800445500",
-            "web_site": "https://id.lepida.it/idm/app/#lepida-spid-id",
-            "recover_username": "https://id.lepida.it/lepidaid/recuperausername",
-            "recover_password": "https://id.lepida.it/lepidaid/recuperapassword"
-         },
-         "namirialid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Namirial selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://support.namirial.com/it/faq/faq-tsp/faq-tsp-spid) fornite dal tuo Identity Provider.",
-            "helpdesk_form": "https://support.namirial.com/it/supporto-tecnico",
-            "phone": "003907163494",
-            "web_site": "https://www.namirialtsp.com/spid/",
-            "recover_username": "https://portal.namirialtsp.com/public/retrieveUsername.xhtml",
-            "recover_password": "https://portal.namirialtsp.com/public/resetPassword.xhtml"
-         },
-         "posteid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Poste Italiane  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.poste.it/faq-poste-id.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://posteid.poste.it/risorse/condivise/doc/manuale_operativo.pdf).",
-            "helpdesk_form": "https://www.poste.it/scrivici.html",
-            "phone": "800007777",
-            "web_site": "https://posteid.poste.it",
-            "recover_username": "https://posteid.poste.it/recuperocredenziali.shtml",
-            "recover_password": "https://posteid.poste.it/recuperocredenziali.shtml"
-         },
-         "sielteid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Sielte  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.sielteid.it/faq.html) fornite dal tuo Identity Provider ed il [Manuale Utente](https://www.sielteid.it/documents/ManualeUtente.pdf).",
-            "helpdesk_form": "https://www.sielteid.it/contact.html#blocco-contatti-form",
-            "phone": "00390957171301",
-            "web_site": "https://www.sielteid.it/che-cos-e-sielteid.html",
-            "recover_password": "https://myid.sieltecloud.it/profile/forgotPassword"
-         },
-         "spiditalia": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Register mediante il bottone qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare le [FAQ](https://www.register.it/spid#pgc-23051-10-0) fornite dal tuo Identity Provider ed il [Manuale Utente](https://spid.register.it/doc/Guida_Utente_SPID.pdf).",
-            "phone": "+390355787979",
-            "web_site": "https://www.register.it/spid/ ",
-            "recover_username": "https://spid.register.it/selfcare/recovery/username ",
-            "recover_password": "https://spid.register.it/selfcare/recovery/password"
-         },
-         "timid": {
-            "description": "Se riscontri altri problemi nella procedura di autenticazione, puoi contattare il servizio dedicato offerto da Tim  selezionando una delle opzioni disponibili qui di seguito. \nInoltre, per ulteriori informazioni puoi consultare il [Manuale Utente](https://www.trusttechnologies.it/wp-content/uploads/SPIDPRIN.TT_.DPMU15000.03-Guida-Utente-al-servizio-TIM-ID.pdf) fornito dal tuo Identity Provider.",
-            "email": "supportotimid@telecomitalia.it",
-            "helpdesk_form": "https://www.trusttechnologies.it/contatti/#form",
-            "phone": "800405800",
-            "web_site": "https://spid.tim.it/tim-id-portal",
-            "recover_username": "https://login.id.tim.it/mps/fu.php",
-            "recover_password": "https://login.id.tim.it/mps/fp.php"
-         }
-      }
-   }],
+      ]
+   },
    "en": {
       "screens": [
-        {
-        "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
-        "title": "Pay with your supermarket card",
-        "content": "Here you can add your supermarket card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
-        "faqs": [
-          {
-            "title": "Which supermarket cards can I add?",
-            "body": "You can add only supermarket cards that allow you to pay. Supermarket cards that allow you to collect points or get access to discounts only are not valid."
-          }
-          {
-        "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
-        "title": "Pay with your PagoBANCOMAT card",
-        "content": "Here you can add your PagoBANCOMAT card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet. Before proceeding with the addition of your PagoBANCOMAT cards, please read the privacy policy.",
-        "faqs": [
-          {
-            "title": "Why can't I find my bank?",
-            "body": "Probably your PagoBANCOMAT card has been issued by a different bank. If you press “Add”, IO will search for all the PagoBANCOMAT cards in your name based on your tax code, which is deducted from the SPID or CIE you used to log in."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_ADD_CARD",
-        "title": "Pay with a credit, debit, or prepaid card",
-        "content": "Here you can add your credit, debit, or prepaid card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
-        "faqs": [
-            {
-            "title": "Where do I find the security code?",
-            "body": "The security code, also called CVV or CVS, is a three-digit code on the back of your card. In American Express cards it's called CID, it has four digits and is located on the front. If you can't find the security code, your card probably isn't enabled for online payments."
-          },
-          {
-            "title": "I’m having trouble adding my card. What can I do?",
-            "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n*Your card is not enabled for online purchases; \n\n*Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page] (https://io.italia.it/metodi-pagamento/)."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_PRIVATIVE_DETAIL",
-        "title": "Your supermarket card",
-        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-        "faqs": [
-          {
-            "title": "How can I set this payment method as favorite?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-          },
-          {
-            "title": "How can I delete this payment method?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_BANCOMAT_DETAIL",
-        "title": "Your PagoBANCOMAT card",
-        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-        "faqs": [
-          {
-            "title": "How can I set this payment method as favorite?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-          },
-          {
-            "title": "How can I delete this payment method?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-          },
-        {
-            "title": "Why is the bank's name and logo different from the name and logo on my card?",
-            "body": "Your PagoBANCOMAT card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
-          },
-          {
-            "title": "Why does it say my card is not compatible with in-app payments?",
-            "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n*Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n*Add the second circuit, if your card has the security code and is already enabled for online payments."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_PAYPAL_DETAIL",
-        "title": "Your PayPal account",
-        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-        "faqs": [
-          {
-            "title": "How can I set this payment method as favorite?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-          },
-          {
-            "title": "How can I delete this payment method?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_CREDIT_CARD_DETAIL",
-        "title": "Your card",
-        "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
-        "faqs": [
-          {
-            "title": "How can I set this payment method as favorite?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
-          },
-          {
-            "title": "How can I delete this payment method?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
-          }
-        ]
-      },
-      {
-        "route_name": "WALLET_HOME",
-        "title": "What can you do in your Wallet",
-        "content": "In the Wallet you can find the payment methods you have added, the bonuses and initiatives you have joined and the history of transactions made with pagoPA, the platform for payments to the Public Administration. Here, you can also pay all the payment notices with the pagoPA logo.",
-        "faqs": [
-          {
-            "title": "How can I pay on IO?",
-            "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page] (https://io.italia.it/metodi-pagamento)."
-          },
-          {
-            "title": "How do I add a payment method?",
-            "body": "Go to the Wallet, press “Add”, and then “Payment method”. Select the method you want to add and enter the required information."
-          },
-          {
-            "title": "What bonuses, discounts or other initiatives can I apply for?",
-            "body": "Go to Wallet, select “Add” and “Discounts, bonuses and other initiatives”. You will see a list with all the bonuses and initiatives you can apply for through IO."
-          },
-          {
-            "title": "I have trouble adding a payment method. What can I do?",
-            "body": "Go to the [payment method addition status page] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
-          },
-          {
-            "title": "How can I delete a payment method?",
-            "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
-          },
-          {
-            "title": "I have trouble with a payment. What can I do?",
-            "body": "Go to [your payment status page] (ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
-          },
-          {
-            "title": "Where do I find the payments I have made?",
-            "body": "In the Wallet you will find a list of successful payments you have made through IO. The list also includes payments made through the partner institutions' website or app, if you logged in with SPID."
-          },
-          {
-            "title": "Can I pay a notice that I did not receive through IO?",
-            "body": "Yes, if the notice features the pagoPA logo and QR code or Notice Code. To do so, go to the Wallet, scan the QR or enter the Notice Code and complete the payment."
-          },
-          {
-            "title": "What is a QR code?",
-            "body": "The QR code is a square image made of white and black elements. When you scan it with a device's camera, it provides direct access to digital content, such as a website, a payment, or an item.\The QR code you find on payment notices is linked to a Notice Code. If you go to your Wallet, press "Pay Notice" and scan the code with your camera, you can pay the notice without having to manually enter information such as a description, amount or tax code."
-          },
-          {
-            "title": "What is pagoPA?",
-            "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website] (https://www.pagopa.gov.it/)."
-          },
-          {
-            "title": "How can I learn more about digital payments?",
-            "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section] (https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
-          },
-        ]
-      },
-      {
+         {
+            "route_name": "WALLET_ONBOARDING_PRIVATIVE_CHOOSER_ISSUE",
+            "title": "Pay with your supermarket card",
+            "content": "Here you can add your supermarket card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
+            "faqs": [
+               {
+                  "title": "Which supermarket cards can I add?",
+                  "body": "You can add only supermarket cards that allow you to pay. Supermarket cards that allow you to collect points or get access to discounts only are not valid."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ONBOARDING_BANCOMAT_START",
+            "title": "Pay with your PagoBANCOMAT card",
+            "content": "Here you can add your PagoBANCOMAT card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet. Before proceeding with the addition of your PagoBANCOMAT cards, please read the privacy policy.",
+            "faqs": [
+               {
+                  "title": "Why can't I find my bank?",
+                  "body": "Probably your PagoBANCOMAT card has been issued by a different bank. If you press “Add”, IO will search for all the PagoBANCOMAT cards in your name based on your tax code, which is deducted from the SPID or CIE you used to log in."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_ADD_CARD",
+            "title": "Pay with a credit, debit, or prepaid card",
+            "content": "Here you can add your credit, debit, or prepaid card as a payment method. To edit the settings of this payment method or delete it, select the card in your Wallet.",
+            "faqs": [
+               {
+                  "title": "Where do I find the security code?",
+                  "body": "The security code, also called CVV or CVS, is a three-digit code on the back of your card. In American Express cards it's called CID, it has four digits and is located on the front. If you can't find the security code, your card probably isn't enabled for online payments."
+               },
+               {
+                  "title": "I’m having trouble adding my card. What can I do?",
+                  "body": "In this case, we recommend that you contact your bank. The reasons may be different, but the most frequent cases are: \n\n*Your card is not enabled for online purchases; \n\n*Your card has been “paused”\n\n*;You have not yet activated the 3DS service, a security system related to online payments. You can see a detailed list of supported methods on the [Payment Methods page] (https://io.italia.it/metodi-pagamento/)."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_PRIVATIVE_DETAIL",
+            "title": "Your supermarket card",
+            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+            "faqs": [
+               {
+                  "title": "How can I set this payment method as favorite?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+               },
+               {
+                  "title": "How can I delete this payment method?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_BANCOMAT_DETAIL",
+            "title": "Your PagoBANCOMAT card",
+            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+            "faqs": [
+               {
+                  "title": "How can I set this payment method as favorite?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+               },
+               {
+                  "title": "How can I delete this payment method?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+               },
+               {
+                  "title": "Why is the bank's name and logo different from the name and logo on my card?",
+                  "body": "Your PagoBANCOMAT card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
+               },
+               {
+                  "title": "Why does it say my card is not compatible with in-app payments?",
+                  "body": "The PagoBANCOMAT network does not let you make online payments. If you want to pay on IO with your card, you can: \n*Add BANCOMAT Pay to the Wallet, if your bank offers this service;\n*Add the second circuit, if your card has the security code and is already enabled for online payments."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_PAYPAL_DETAIL",
+            "title": "Your PayPal account",
+            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+            "faqs": [
+               {
+                  "title": "How can I set this payment method as favorite?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+               },
+               {
+                  "title": "How can I delete this payment method?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press on “Delete this payment method”."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_CREDIT_CARD_DETAIL",
+            "title": "Your card",
+            "content": "Here you can see the details of this payment method, edit the settings or delete it from the Wallet.",
+            "faqs": [
+               {
+                  "title": "How can I set this payment method as favorite?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card of this method and set it as favorite."
+               },
+               {
+                  "title": "How can I delete this payment method?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
+               }
+            ]
+         },
+         {
+            "route_name": "WALLET_HOME",
+            "title": "What can you do in your Wallet",
+            "content": "In the Wallet you can find the payment methods you have added, the bonuses and initiatives you have joined and the history of transactions made with pagoPA, the platform for payments to the Public Administration. Here, you can also pay all the payment notices with the pagoPA logo.",
+            "faqs": [
+               {
+                  "title": "How can I pay on IO?",
+                  "body": "You can pay with credit, debit and prepaid cards or with PayPal. You can find the updated list of available methods on the [payment methods page] (https://io.italia.it/metodi-pagamento)."
+               },
+               {
+                  "title": "How do I add a payment method?",
+                  "body": "Go to the Wallet, press “Add”, and then “Payment method”. Select the method you want to add and enter the required information."
+               },
+               {
+                  "title": "What bonuses, discounts or other initiatives can I apply for?",
+                  "body": "Go to Wallet, select “Add” and “Discounts, bonuses and other initiatives”. You will see a list with all the bonuses and initiatives you can apply for through IO."
+               },
+               {
+                  "title": "I have trouble adding a payment method. What can I do?",
+                  "body": "Go to the [payment method addition status page] (ioit://CREDIT_CARD_ONBOARDING_ATTEMPTS_SCREEN), select the failed addition attempt and contact Support."
+               },
+               {
+                  "title": "How can I delete a payment method?",
+                  "body": "Your payment methods are displayed as cards in the top part of the screen. Select the card you want to delete and press “Delete this payment method”."
+               },
+               {
+                  "title": "I have trouble with a payment. What can I do?",
+                  "body": "Go to [your payment status page] (ioit://PAYMENTS_HISTORY_SCREEN), select the failed payment attempt and contact Support."
+               },
+               {
+                  "title": "Where do I find the payments I have made?",
+                  "body": "In the Wallet you will find a list of successful payments you have made through IO. The list also includes payments made through the partner institutions' website or app, if you logged in with SPID."
+               },
+               {
+                  "title": "Can I pay a notice that I did not receive through IO?",
+                  "body": "Yes, if the notice features the pagoPA logo and QR code or Notice Code. To do so, go to the Wallet, scan the QR or enter the Notice Code and complete the payment."
+               },
+               {
+                  "title": "What is a QR code?",
+                  "body": "The QR code is a square image made of white and black elements. When you scan it with a device's camera, it provides direct access to digital content, such as a website, a payment, or an item.\nThe QR code you find on payment notices is linked to a Notice Code. If you go to your Wallet, press 'Pay Notice' and scan the code with your camera, you can pay the notice without having to manually enter information such as a description, amount or tax code."
+               },
+               {
+                  "title": "What is pagoPA?",
+                  "body": "pagoPA is a platform that makes payments to the Public Administration easier, safer and more transparent. Among other benefits, it helps increase the use of e-payment methods and make individuals able to choose how to pay, highlighting the commission costs. To learn more, [go to the pagoPA website] (https://www.pagopa.gov.it/)."
+               },
+               {
+                  "title": "How can I learn more about digital payments?",
+                  "body": "In order to learn more about the topics of your interest related to the world of payments, you can read the resources provided by Banca d’Italia as part of its Financial Education programs, such as the [dedicated section] (https://economiapertutti.bancaditalia.it/pagare/) of the website [L’Economia per tutti](https://economiapertutti.bancaditalia.it/) and the [Guide to Payments in Electronic Commerce]. \n\nFor example, if you want to learn more about the payment methods you can add to the Wallet of the IO app, you can read the dedicated information sheets, such as [credit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-credito/), [debit card] (https://economiapertutti.bancaditalia.it/pagare/carta-di-debito/), [prepaid card] (https://economiapertutti.bancaditalia.it/pagare/carta-prepagata/), [co-badge card] (https://economiapertutti.bancaditalia.it/pagare/carte_co-badge_multifunzione/) or other digital services, [such as PayPal] (https://economiapertutti.bancaditalia.it/notizie/parliamo-di-pagamenti-elettronici-e-online/#B4)."
+               }
+            ]
+         },
+         {
             "route_name": "WALLET_ONBOARDING_COBADGE_CHOOSE_TYPE",
             "title": "Add the second network of your PagoBANCOMAT card",
             "content": "In order to properly add the international network associated to your PagoBANCOMAT card, we need to know if you have ever used this card online, so that we can redirect you to the relevant page.",
@@ -1239,7 +1245,7 @@
             "title": "Add the second network of your PagoBANCOMAT card",
             "content": "This feature allows you to search for all the cards with international network (Maestro, Mastercard, Visa and V-Pay) in your name.",
             "faqs": [
-              {
+               {
                   "title": "Can I add cards with an international network?",
                   "body": "Yes, you can add debit or credit cards with an international network (Maestro, Mastercard, VISA and V-Pay), even if they are not enabled for online payments. The cards must be in your name and issued by the [participating banks](https://io.italia.it/cashback/carta-non-abilitata-pagamenti-online)."
                },
@@ -1252,7 +1258,7 @@
          {
             "route_name": "WALLET_ONBOARDING_COBADGE_SEARCH_AVAILABLE",
             "title": "Add the second network of your PagoBANCOMAT card",
-            "content": "Here you can see all the cards in your name with an international network (Maestro, Mastercard, Visa and V-Pay), issued by the banks participating in the service. If you don't want to add one of the cards listed, press “Skip" and go to the next one.",
+            "content": "Here you can see all the cards in your name with an international network (Maestro, Mastercard, Visa and V-Pay), issued by the banks participating in the service. If you don't want to add one of the cards listed, press 'Skip' and go to the next one.",
             "faqs": [
                {
                   "title": "Why is the expiration date different?",
@@ -1281,47 +1287,48 @@
                   "title": "Why is the bank's name and logo different from the name and logo on my card?",
                   "body": "Your card has probably been issued by a different bank. This happens mostly with online banks or in case of mergers."
                },
-              {
+               {
                   "title": "Why is the expiration date different?",
                   "body": "In some cases, the expiration date displayed in the app may be different from the date printed on the card, but this does not affect the addition."
                },
                {
                   "title": "Why is the card number different?",
                   "body": "IO shows you the last 4 digits of the international network. This number is also indicated on the receipts of purchases made with this network. In some cases, the card may show a different number, but this does not affect the addition."
-               },
+               }
             ]
-          },
-          {
-        "route_name": "UADONATION_ROUTES_WEBVIEW",
-        "title": "Donations Ukraine",
-        "content": "In this page, you can make a donation to charities assisting the civilian victims of the crisis in Ukraine.",
-        "faqs": [
-          {
-            "title": "How can I make a donation?",
-            "body": "To donate, choose a charity from the list. Then select the amount you want to donate and press 'Continue'. Use a supported payment method or select it from your Wallet. Finally, press 'Pay' to complete the donation."
-          },
-          {
-            "title": "What payment methods can I use to make the donation?",
-            "body": "You can donate with a Visa, Maestro and Mastercard credit, debit or prepaid card and with PayPal."
-          },
-          {
-            "title": "Is there a minimum amount?",
-            "body": "Yes, you can donate from a minimum of €5 to a maximum of €200. If you want to donate higher amounts, you can repeat the donation."
-          },
-          {
-            "title": "Is there a commission cost associated with the donation?",
-            "body": " If you donate with a Visa, Maestro and Mastercard credit, debit or prepaid card, no commissions are charged."
-          },
-          {
-            "title": "After donating, I did not receive the email with the receipt. What can I do?",
-            "body": "After donating, you will receive an email with the receipt. If you don't, check your spam folder and make sure the address you find under Profile > Your Information is correct. We recommend that you keep your receipt, along with original documentation of the payment (such as the bank or credit card statement) for tax purposes."
-          },
-          {
-            "title": "I represent a charity: can I participate in the initiative?",
-            "body": "For information on how to participate in the initiative, email affari.istituzionali@pagopa.it."
-          }
-        ]
-      }],
+         },
+         {
+            "route_name": "UADONATION_ROUTES_WEBVIEW",
+            "title": "Donations Ukraine",
+            "content": "In this page, you can make a donation to charities assisting the civilian victims of the crisis in Ukraine.",
+            "faqs": [
+               {
+                  "title": "How can I make a donation?",
+                  "body": "To donate, choose a charity from the list. Then select the amount you want to donate and press 'Continue'. Use a supported payment method or select it from your Wallet. Finally, press 'Pay' to complete the donation."
+               },
+               {
+                  "title": "What payment methods can I use to make the donation?",
+                  "body": "You can donate with a Visa, Maestro and Mastercard credit, debit or prepaid card and with PayPal."
+               },
+               {
+                  "title": "Is there a minimum amount?",
+                  "body": "Yes, you can donate from a minimum of €5 to a maximum of €200. If you want to donate higher amounts, you can repeat the donation."
+               },
+               {
+                  "title": "Is there a commission cost associated with the donation?",
+                  "body": " If you donate with a Visa, Maestro and Mastercard credit, debit or prepaid card, no commissions are charged."
+               },
+               {
+                  "title": "After donating, I did not receive the email with the receipt. What can I do?",
+                  "body": "After donating, you will receive an email with the receipt. If you don't, check your spam folder and make sure the address you find under Profile > Your Information is correct. We recommend that you keep your receipt, along with original documentation of the payment (such as the bank or credit card statement) for tax purposes."
+               },
+               {
+                  "title": "I represent a charity: can I participate in the initiative?",
+                  "body": "For information on how to participate in the initiative, email affari.istituzionali@pagopa.it."
+               }
+            ]
+         }
+      ],
       "idps": {
          "arubaid": {
             "description": "For problems encountered during the authentication process, you can reach the support desk of Aruba by selecting  one of the options presented below.",
@@ -1399,3 +1406,4 @@
          }
       }
    }
+}


### PR DESCRIPTION
I have:
- updated and added here all the FAQs of Wallet_Home, which were not remotized;
- added specific FAQs for each payment method, both in the onboarding method process and in the card detail of each method once this has been added;
- Deleted any reference to Cashback (also when it comes to methods such as BancomatPAY)
- Deleted a route that is no longer relevant(WALLET_PAYMENT_METHOD_DETAIL) and another one whose name was incorrect (WALLET_ONBOARDING_BANCOMAT_CHOOSE_BANK)
- Added an FAQ regarding the Back of Italy's financial education program ("Come posso saperne di più sui pagamenti digitali?")
- Added the same FAQs in the English version — all of which were not remotized up to now.