### PR TITLE
[IA-843] Add a remote Feature Flag for the Poste Data Matrix

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -403,6 +403,7 @@ definitions:
       - fims
       - premiumMessages
       - cdc
+      - barcodesScanner
     properties:
       bpd:
         $ref: "#/definitions/BpdConfig"
@@ -430,6 +431,8 @@ definitions:
         $ref: "#/definitions/PremiumMessagesConfig"
       cdc:
         $ref: "#/definitions/CdcConfig"
+      barcodesScanner:
+        $ref: "#/definitions/BarcodesScannerConfig"
   BpdConfig:
     type: object
     description: A specific config for BPD bonus
@@ -674,6 +677,15 @@ definitions:
       enabled:
         type: boolean
         description: "If true, are visible the entry points: bonus menu, carousel, service page cta, and message cta"
+  BarcodesScannerConfig:
+    type: object
+    description: "A configuration for the barcodes scanner in the payment section"
+    required:
+      - dataMatrixPosteEnabled
+    properties:
+      dataMatrixPosteEnabled:
+        type: boolean
+        description: "If true, a Poste Data Matrix can be scansioned to make a payment"
 
 
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.12",
+  "version": "1.0.13",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -49,6 +49,9 @@
     },
     "cdc": {
       "enabled": false
+    },
+    "barcodesScanner": {
+      "dataMatrixPosteEnabled": false
     }
   },
   "sections": {


### PR DESCRIPTION
This PR is going to add a configuration for the IO app barcode scanner with the Poste Data Matrix.

The configuration object `BarcodesScannerConfig` has been made "abstract" because in the future we could address other types of barcodes for different organizations.

⚠️ This PR is going to increase the version number too in order to instantly create the new tag.