### PR TITLE
[AP-31] Add cdc section status

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -365,6 +365,8 @@ definitions:
         $ref: "#/definitions/SectionStatus"
       fims:
         $ref: "#/definitions/SectionStatus"
+      cdc:
+        $ref: "#/definitions/SectionStatus"
   SectionStatus:
     type: object
     description: The status of a specific app section

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -79,6 +79,18 @@
         "en-EN": "The Cashback initiative has ended."
       }
     },
+    "cdc": {
+      "is_visible": false,
+      "level": "warning",
+      "message": {
+        "it-IT": "",
+        "en-EN": ""
+      },
+      "badge": {
+        "it-IT": "",
+        "en-EN": ""
+      }
+    },
     "cgn": {
       "is_visible": false,
       "level": "warning",


### PR DESCRIPTION
This PR adds the `cdc` section in the section status.
Please, remember when you merge the PR to create the tag with the new version `1.0.14`