### PR TITLE
Enable the `dataMatrixPosteEnabled` remote feature flag

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -51,7 +51,7 @@
       "enabled": false
     },
     "barcodesScanner": {
-      "dataMatrixPosteEnabled": false
+      "dataMatrixPosteEnabled": true
     }
   },
   "sections": {


### PR DESCRIPTION
This PR is going to enable the Poste Data Matrix feature flag in order to start testing in the internal beta release.