### PR TITLE
Enable the premium messages opt-out feature flag

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -45,7 +45,7 @@
       }
     },
     "premiumMessages": {
-      "opt_in_out_enabled": false
+      "opt_in_out_enabled": true
     },
     "cdc": {
       "enabled": false


### PR DESCRIPTION
This PR is going to enable the `opt_in_out_enabled` feature flag related to the "Spunta Blu".