### PR TITLE
[IAMVL-91] Add a remote configuration for the PN feature

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -407,6 +407,7 @@ definitions:
       - cdc
       - barcodesScanner
       - fci
+      - pn
     properties:
       bpd:
         $ref: "#/definitions/BpdConfig"
@@ -438,6 +439,8 @@ definitions:
         $ref: "#/definitions/BarcodesScannerConfig"
       fci:
         $ref: "#/definitions/FciConfig"
+      pn:
+        $ref: "#/definitions/PnConfig"
   BpdConfig:
     type: object
     description: A specific config for BPD bonus
@@ -700,5 +703,18 @@ definitions:
       enabled:
         type: boolean
         description: "If true, the user (signer) can digitally signs documents"
+  PnConfig:
+    type: object
+    description: "A configuration for the PN feature"
+    required:
+      - enabled
+      - frontend_url
+    properties:
+      enabled:
+        type: boolean
+        description: "If true, the app can activate the PN service and open messages (aka avvisi di cortesia) from PN"
+      frontend_url:
+        type: string
+        description: "The URL of the PN web frontend"
 
 

--- a/definitions.yml
+++ b/definitions.yml
@@ -708,7 +708,6 @@ definitions:
     description: "A configuration for the PN feature"
     required:
       - enabled
-      - frontend_url
     properties:
       enabled:
         type: boolean

--- a/definitions.yml
+++ b/definitions.yml
@@ -708,6 +708,7 @@ definitions:
     description: "A configuration for the PN feature"
     required:
       - enabled
+      - frontend_url
     properties:
       enabled:
         type: boolean

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.15",
+  "version": "1.0.16",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -55,6 +55,10 @@
     },
     "fci": {
       "enabled": false
+    },
+    "pn": {
+      "enabled": true,
+      "frontend_url": "https://notifichedigitali.it"
     }
   },
   "sections": {


### PR DESCRIPTION
This PR is going to add a remote configuration for the PN feature. The configuration will be used for:

- enabling/disabling the feature
- configuring the URL that will be open when the user wants to check the complete status history of a notification

<img width="332" alt="Schermata 2022-07-25 alle 10 29 27" src="https://user-images.githubusercontent.com/467098/180733619-efb614c8-1dfd-4d52-a27c-fa03c05e65b2.png">

