### PR TITLE
Change from allowedPspsByOrigin to preferredPspsByOrigin

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -723,9 +723,9 @@ definitions:
     type: object
     description: "Configuration data related to payments"
     properties: 
-      allowedPspsByOrigin:
-       $ref: "#/definitions/AllowedPspsByOrigin"
-  AllowedPspsByOrigin:
+      preferredPspsByOrigin:
+       $ref: "#/definitions/PreferredPspsByOrigin"
+  PreferredPspsByOrigin:
     type: object
     properties: 
       "poste_datamatrix_scan":

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.17",
+  "version": "1.0.18",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -61,7 +61,7 @@
       "frontend_url": "https://cittadini.notifichedigitali.it"
     },
     "payments": {
-      "allowedPspsByOrigin": {
+      "preferredPspsByOrigin": {
         "poste_datamatrix_scan": ["BPPIITRRXXX"]
       }
     }


### PR DESCRIPTION
The logic to filter psps by origin is changed so this PR changes the name of in the config to have a better meaning.