### PR TITLE
Paytipper (PayPal) Scheduled Maintenance

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -18,7 +18,7 @@
       "tool": "zendesk"
     },
     "paypal": {
-      "enabled": true
+      "enabled": false
     },
     "bancomatPay": {
       "display": true,
@@ -152,11 +152,11 @@
       }
     },
     "wallets": {
-      "is_visible": false,
-      "level": "warning",
+      "is_visible": true,
+      "level": "normal",
       "message": {
-        "it-IT": "Dalle 20 alle 23 non sarà possibile pagare con PayPal.",
-        "en-EN": "PayPal services won't be available from 8 to 11 PM."
+        "it-IT": "PayPal è in manutenzione, tornerà presto disponibile.",
+        "en-EN": "PayPal is under maintenance, it will be back soon."
       }
     },
     "ingress": {


### PR DESCRIPTION
This PR sets PayPal services under maintenance:

1. Enables the Feature Flag to disable PayPal method
2. Enables the banner in the Wallet page