### PR TITLE
[IOAPPFD0-13] Scheduled Maintenance (Paytipper)

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -19,7 +19,7 @@
       "tool": "zendesk"
     },
     "paypal": {
-      "enabled": true
+      "enabled": false
     },
     "bancomatPay": {
       "display": true,
@@ -153,7 +153,7 @@
       }
     },
     "wallets": {
-      "is_visible": false,
+      "is_visible": true,
       "level": "normal",
       "message": {
         "it-IT": "PayPal è in manutenzione, tornerà presto disponibile.",


### PR DESCRIPTION
This PR:
- disables the FF for PayPal
- enables the banner in Wallet page

The scheduled maintenance will start on 9/11/2022 at 9pm. 
More info: https://status.pagopa.gov.it/incidents/clcplg6s9gxb