### PR TITLE
Activate Banner in Wallet

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -153,11 +153,15 @@
       }
     },
     "wallets": {
-      "is_visible": false,
-      "level": "normal",
+      "is_visible": true,
+      "level": "warning",
+      "web_url": {
+        "it-IT": "https://status.pagopa.gov.it/incidents/z6mn93mpvyyd",
+        "en-EN": "https://status.pagopa.gov.it/incidents/z6mn93mpvyyd"
+      },
       "message": {
-        "it-IT": "PayPal è in manutenzione, tornerà presto disponibile.",
-        "en-EN": "PayPal is under maintenance, it will be back soon."
+        "it-IT": "pagoPA è in manutenzione, tornerà presto disponibile.",
+        "en-EN": "pagoPA is under maintenance, it will be back soon."
       }
     },
     "ingress": {


### PR DESCRIPTION
This PR enables a warning banner in wallet section, informing users about the schedule maintenance.
More info here: https://status.pagopa.gov.it/incidents/z6mn93mpvyyd

**To be merged at the beginning of the scheduled maintenance**