### PR TITLE
fix: Update FCI config  reintroducing enabled prop to support old app version

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -721,12 +721,12 @@ definitions:
       - min_app_version
       - enabled
     properties:
-    enabled:
-      type: boolean
-      description: "If true, the app can activate the Firma con IO service and digitally signs documents"
-    min_app_version:
-      $ref: "#/definitions/VersionPerPlatform"
-      description: "If min app version supported, the test user (signer) can digitally signs documents"
+      enabled:
+        type: boolean
+        description: "If true, the app can activate the Firma con IO service and digitally signs documents"
+      min_app_version:
+        $ref: "#/definitions/VersionPerPlatform"
+        description: "If min app version supported, the test user (signer) can digitally signs documents"
   PnConfig:
     type: object
     description: "A configuration for the PN feature"

--- a/definitions.yml
+++ b/definitions.yml
@@ -719,7 +719,11 @@ definitions:
     description: "A configuration for the Firma con IO feature"
     required:
       - min_app_version
+      - enabled
     properties:
+    enabled:
+      type: boolean
+      description: "If true, the app can activate the Firma con IO service and digitally signs documents"
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"
         description: "If min app version supported, the test user (signer) can digitally signs documents"

--- a/definitions.yml
+++ b/definitions.yml
@@ -724,9 +724,9 @@ definitions:
     enabled:
       type: boolean
       description: "If true, the app can activate the Firma con IO service and digitally signs documents"
-      min_app_version:
-        $ref: "#/definitions/VersionPerPlatform"
-        description: "If min app version supported, the test user (signer) can digitally signs documents"
+    min_app_version:
+      $ref: "#/definitions/VersionPerPlatform"
+      description: "If min app version supported, the test user (signer) can digitally signs documents"
   PnConfig:
     type: object
     description: "A configuration for the PN feature"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -55,7 +55,11 @@
       "dataMatrixPosteEnabled": true
     },
     "fci": {
-      "enabled": false
+      "enabled": false,
+      "min_app_version": {
+        "ios": "2.22.0.3",
+        "android": "2.22.0.3"
+      }
     },
     "lollipop": {
       "enabled": false


### PR DESCRIPTION
This PR fix the spec of `Firma con IO` reintroducing the `enabled` prop