### PR TITLE
chore(IDPay): [IODPAY-90] Add `IdPayConfig` feature flag

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -735,11 +735,7 @@ definitions:
     description: "A configuration for the IdPay feature"
     required:
       - min_app_version
-      - enabled
     properties:
-      enabled:
-        type: boolean
-        description: "If true, the app can activate the IdPay service and the dedicated sections of the app"
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"
         description: "If min app version supported, the test user can onboard, configure and monitor an IdPay initiative"

--- a/definitions.yml
+++ b/definitions.yml
@@ -529,7 +529,7 @@ definitions:
     properties:
       tool:
         type: string
-        enum: [ none,zendesk,instabug,web ]
+        enum: [none, zendesk, instabug, web]
         description: "none: also used as default, the assistance is not visible; zendesk: the assistance is managed with zendesk; instabug: the assistance is managed with instabug; web: the assistance is managed with a web form;"
   Zendesk:
     type: object
@@ -727,6 +727,19 @@ definitions:
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"
         description: "If min app version supported, the test user (signer) can digitally signs documents"
+  IdPayConfig:
+    type: object
+    description: "A configuration for the IdPay feature"
+    required:
+      - min_app_version
+      - enabled
+    properties:
+      enabled:
+        type: boolean
+        description: "If true, the app can activate the IdPay service and the dedicated sections of the app"
+      min_app_version:
+        $ref: "#/definitions/VersionPerPlatform"
+        description: "If min app version supported, the test user can onboard, configure and monitor an IdPay initiative"
   PnConfig:
     type: object
     description: "A configuration for the PN feature"
@@ -743,12 +756,12 @@ definitions:
   PaymentsConfig:
     type: object
     description: "Configuration data related to payments"
-    properties: 
+    properties:
       preferredPspsByOrigin:
-       $ref: "#/definitions/PreferredPspsByOrigin"
+        $ref: "#/definitions/PreferredPspsByOrigin"
   PreferredPspsByOrigin:
     type: object
-    properties: 
+    properties:
       "poste_datamatrix_scan":
         type: array
         items:

--- a/definitions.yml
+++ b/definitions.yml
@@ -407,6 +407,7 @@ definitions:
       - cdc
       - barcodesScanner
       - fci
+      - idPay
       - lollipop
       - pn
       - payments

--- a/definitions.yml
+++ b/definitions.yml
@@ -443,6 +443,8 @@ definitions:
         $ref: "#/definitions/BarcodesScannerConfig"
       fci:
         $ref: "#/definitions/FciConfig"
+      idPay:
+        $ref: "#/definitions/IdPayConfig"
       lollipop:
         $ref: "#/definitions/LollipopConfig"
       pn:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.21",
+  "version": "1.0.23",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -63,8 +63,8 @@
     },
     "idPay": {
       "min_app_version": {
-        "ios": "2.22.0.3",
-        "android": "2.22.0.3"
+        "ios": "*",
+        "android": "*"
       }
     },
     "lollipop": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -61,6 +61,13 @@
         "android": "2.22.0.3"
       }
     },
+    "idPay": {
+      "enabled": false,
+      "min_app_version": {
+        "ios": "2.22.0.3",
+        "android": "2.22.0.3"
+      }
+    },
     "lollipop": {
       "enabled": false
     },

--- a/status/backend.json
+++ b/status/backend.json
@@ -63,8 +63,8 @@
     },
     "idPay": {
       "min_app_version": {
-        "ios": "*",
-        "android": "*"
+        "ios": "0.0.0.0",
+        "android": "0.0.0.0"
       }
     },
     "lollipop": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -62,7 +62,6 @@
       }
     },
     "idPay": {
-      "enabled": false,
       "min_app_version": {
         "ios": "2.22.0.3",
         "android": "2.22.0.3"


### PR DESCRIPTION
## Description

This PR introduces the feature flag for the IDPay features with the properties `enabled` and the recently introduced `min_app_version`, allowing the activation by version and by platform.

The feature flag is:

```yaml
  IdPayConfig:
    type: object
    description: "A configuration for the IdPay feature"
    required:
      - min_app_version
    properties:
      min_app_version:
        $ref: "#/definitions/VersionPerPlatform"
        description: "If min app version supported, the test user can onboard, configure and monitor an IdPay initiative"
  ```
  
  