### PR TITLE
chore(Firma con IO): [SFEQS-1406] Add service id to the FCI remote config

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -735,6 +735,9 @@ definitions:
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"
         description: "If min app version supported, the test user (signer) can digitally signs documents"
+      service_id:
+        type: string
+        description: "The service id for the Firma con IO feature"
   IdPayConfig:
     type: object
     description: "A configuration for the IdPay feature"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.24",
+  "version": "1.0.25",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -59,7 +59,8 @@
       "min_app_version": {
         "ios": "2.22.0.3",
         "android": "2.22.0.3"
-      }
+      },
+      "service_id": "01GQQZ9HF5GAPRVKJM1VDAVFHM"
     },
     "idPay": {
       "min_app_version": {


### PR DESCRIPTION
### Short description
The `service-id` prop is added to `FciConfig` by this PR. During the signing flow, the app should check the user's ability to receive a message. To accomplish this, the app must be aware of the `service-id` of the feature `Firma con IO`. Because this information is not available during the signing procedure, adding a new remote property is the best option to retrieve the `service-id`.

### Changes
* Update FciConfig in definitions.yml
* Update backend.json