### PR TITLE
[IOCOM-270] Added PN Opt In Service ID

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -770,6 +770,7 @@ definitions:
     required:
       - enabled
       - frontend_url
+      - optInServiceId
     properties:
       enabled:
         type: boolean
@@ -777,6 +778,9 @@ definitions:
       frontend_url:
         type: string
         description: "The URL of the PN web frontend"
+      optInServiceId:
+        type: string
+        description: "The ID of the standard PN service that sends the OptIn message"
   PaymentsConfig:
     type: object
     description: "Configuration data related to payments"

--- a/definitions.yml
+++ b/definitions.yml
@@ -780,7 +780,7 @@ definitions:
         description: "The URL of the PN web frontend"
       optInServiceId:
         type: string
-        description: "The ID of the standard PN service that sends the OptIn  message"
+        description: "The ID of the standard PN service that sends the OptIn message"
   PaymentsConfig:
     type: object
     description: "Configuration data related to payments"

--- a/definitions.yml
+++ b/definitions.yml
@@ -780,7 +780,7 @@ definitions:
         description: "The URL of the PN web frontend"
       optInServiceId:
         type: string
-        description: "The ID of the standard PN service that sends the OptIn message"
+        description: "The ID of the standard PN service that sends the OptIn  message"
   PaymentsConfig:
     type: object
     description: "Configuration data related to payments"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.25",
+  "version": "1.0.26",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -76,7 +76,8 @@
     },
     "pn": {
       "enabled": true,
-      "frontend_url": "https://cittadini.notifichedigitali.it"
+      "frontend_url": "https://cittadini.notifichedigitali.it",
+      "optInServiceId": "01G74SW1PSM6XY2HM5EGZHZZET"
     },
     "payments": {
       "preferredPspsByOrigin": {


### PR DESCRIPTION
This PR adds the PN OptIn Service Id that allows the IO App to properly identify a PN message as the opt-in one