### PR TITLE
[IOCOM-PN] Min app version to 2.35.0.1 for PN message preconditions

### DIFF
--- a/status/versionInfo.json
+++ b/status/versionInfo.json
@@ -1,15 +1,15 @@
 {
   "min_app_version": {
-    "ios": "2.30.0.2",
-    "android": "2.30.0.2"
+    "ios": "2.35.0.1",
+    "android": "2.35.0.1"
   },
   "min_app_version_pagopa": {
     "ios": "0.0.0",
     "android": "0.0.0"
   },
   "latest_released_app_version" : {
-    "ios": "2.32.0.1",
-    "android": "2.32.0.1"
+    "ios": "2.36.0.2",
+    "android": "2.36.0.2"
   },
   "rollout_app_version" : {
     "ios": "0.0.0",


### PR DESCRIPTION
This PR sets the `min_app_version` to 2.35.0.1 in order to make sure that any PN message displays the precondition bottom sheet before opening

It also sets the `latest_released_app_version` to the common released one for consistency