### PR TITLE
feat: add SEND subcat for Messages tickets

### DIFF
--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -81,6 +81,13 @@
               }
             },
             {
+              "value": "ho_un_problema_con_un_messaggio_di_send",
+              "description": {
+                "it-IT": "Ho un problema con un messaggio di SEND",
+                "en-EN": "I have an issue with a message from SEND"
+              }
+            },
+            {
               "value": "non_mi_è_arrivato_un_messaggio",
               "description": {
                 "it-IT": "Non mi è arrivato un messaggio",


### PR DESCRIPTION
REASON: For Zendesk ticket submission in app IO: We need to enable the sub-category "Messaggi" ---> "Ho un problema con un messaggio di SEND"