### PR TITLE
fix: add backtick to container name

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ parameters:
 
 variables:
   - name: BLOB_CONTAINER_NAME
-    value: '$web'
+    value: `$web`
   - name: EXCLUDE_PATH
     value: 'README.md;CODEOWNERS;yarn.lock;package.json;azure-pipelines.yml;azure-templates;.node-version;.nvmrc;.prettierrc;jest.config.js;tsconfig.json;tslint.json;definitions;src;.circleci;.git;services-webview'
   - name: NODE_VERSION


### PR DESCRIPTION
## Short description
This PR adds backticks to container name to avoid: 
`##[error]Detected characters in arguments that may not be executed correctly by the shell. Please escape special characters using backtick (`). More information is available here: https://aka.ms/ado/75787`

