### PR TITLE
fix: Escape characters in azure devops pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -46,7 +46,7 @@ variables:
   - name: BLOB_CONTAINER_NAME
     value: '$web'
   - name: EXCLUDE_PATH
-    value: 'README.md;CODEOWNERS;yarn.lock;package.json;azure-pipelines.yml;azure-templates;.node-version;.nvmrc;.prettierrc;jest.config.js;tsconfig.json;tslint.json;definitions;src;.circleci;.git;services-webview'
+    value: 'README.md`;CODEOWNERS`;yarn.lock`;package.json`;azure-pipelines.yml`;azure-templates`;.node-version`;.nvmrc`;.prettierrc`;jest.config.js`;tsconfig.json`;tslint.json`;definitions`;src`;.circleci`;.git`;services-webview'
   - name: NODE_VERSION
     value: '8.11.3'
   - name: YARN_CACHE_FOLDER
@@ -166,7 +166,7 @@ stages:
       jobs:
         - job: publish_assets_test
           steps:  
-            - task: AzureFileCopy@4
+            - task: AzureFileCopy@5
               inputs:
                 SourcePath: '$(System.DefaultWorkingDirectory)/*'
                 azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,36 +142,36 @@ stages:
                   call az cdn endpoint purge -g $(PRODUCTION_RESOURCE_GROUP) -n $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/*"
 
   # D) Copy data from this repository to the storage to make them available on CDN nodes in TEST
-  # - ${{ if eq(parameters.TEST_ENABLE_DATA_COPY, true) }}:
-  - stage: Publish_test
-  #     condition:
-  #       and(
-  #         succeeded(),
-  #         and (
-  #           eq(variables['ENABLE_DATA_COPY'], true),
-  #           or(
-  #             and(
-  #               eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-  #               ne(variables['Build.Reason'], 'Manual')
-  #             ),
-  #             eq(variables['Build.Reason'], 'Manual')
-  #           )
-  #         )
-  #       )
-    pool:
-      vmImage: 'windows-2019'  
-    dependsOn:
-      - Validation
-      - Test
-    jobs:
-      - job: publish_assets_test
-        steps:  
-          - task: AzureFileCopy@5
-            inputs:
-              SourcePath: '$(System.DefaultWorkingDirectory)/*'
-              azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
-              Destination: 'AzureBlob'
-              storage: '$(TEST_STORAGE_ACCOUNT_NAME)'
-              ContainerName: '$(BLOB_CONTAINER_NAME)'
-              AdditionalArgumentsForBlobCopy: '--recursive --exclude-path "$(EXCLUDE_PATH)"'
-            displayName: Copy to container blob ($(TEST_STORAGE_ACCOUNT_NAME))
+  - ${{ if eq(parameters.TEST_ENABLE_DATA_COPY, true) }}:
+    - stage: Publish_test
+      condition:
+        and(
+          succeeded(),
+          and (
+            eq(variables['ENABLE_DATA_COPY'], true),
+            or(
+              and(
+                eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+                ne(variables['Build.Reason'], 'Manual')
+              ),
+              eq(variables['Build.Reason'], 'Manual')
+            )
+          )
+        )
+      pool:
+        vmImage: 'windows-2019'  
+      dependsOn:
+        - Validation
+        - Test
+      jobs:
+        - job: publish_assets_test
+          steps:  
+            - task: AzureFileCopy@4
+              inputs:
+                SourcePath: '$(System.DefaultWorkingDirectory)/*'
+                azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
+                Destination: 'AzureBlob'
+                storage: '$(TEST_STORAGE_ACCOUNT_NAME)'
+                ContainerName: '$(BLOB_CONTAINER_NAME)'
+                AdditionalArgumentsForBlobCopy: '--recursive --exclude-path "$(EXCLUDE_PATH)"'
+              displayName: Copy to container blob ($(TEST_STORAGE_ACCOUNT_NAME))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -142,36 +142,36 @@ stages:
                   call az cdn endpoint purge -g $(PRODUCTION_RESOURCE_GROUP) -n $(ENDPOINT_NAME) --profile-name $(PROFILE_CDN_NAME) --content-paths "/*"
 
   # D) Copy data from this repository to the storage to make them available on CDN nodes in TEST
-  - ${{ if eq(parameters.TEST_ENABLE_DATA_COPY, true) }}:
-    - stage: Publish_test
-      condition:
-        and(
-          succeeded(),
-          and (
-            eq(variables['ENABLE_DATA_COPY'], true),
-            or(
-              and(
-                eq(variables['Build.SourceBranch'], 'refs/heads/master'),
-                ne(variables['Build.Reason'], 'Manual')
-              ),
-              eq(variables['Build.Reason'], 'Manual')
-            )
-          )
-        )
-      pool:
-        vmImage: 'windows-2019'  
-      dependsOn:
-        - Validation
-        - Test
-      jobs:
-        - job: publish_assets_test
-          steps:  
-            - task: AzureFileCopy@5
-              inputs:
-                SourcePath: '$(System.DefaultWorkingDirectory)/*'
-                azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
-                Destination: 'AzureBlob'
-                storage: '$(TEST_STORAGE_ACCOUNT_NAME)'
-                ContainerName: '$(BLOB_CONTAINER_NAME)'
-                AdditionalArgumentsForBlobCopy: '--recursive --exclude-path "$(EXCLUDE_PATH)"'
-              displayName: Copy to container blob ($(TEST_STORAGE_ACCOUNT_NAME))
+  # - ${{ if eq(parameters.TEST_ENABLE_DATA_COPY, true) }}:
+  - stage: Publish_test
+  #     condition:
+  #       and(
+  #         succeeded(),
+  #         and (
+  #           eq(variables['ENABLE_DATA_COPY'], true),
+  #           or(
+  #             and(
+  #               eq(variables['Build.SourceBranch'], 'refs/heads/master'),
+  #               ne(variables['Build.Reason'], 'Manual')
+  #             ),
+  #             eq(variables['Build.Reason'], 'Manual')
+  #           )
+  #         )
+  #       )
+    pool:
+      vmImage: 'windows-2019'  
+    dependsOn:
+      - Validation
+      - Test
+    jobs:
+      - job: publish_assets_test
+        steps:  
+          - task: AzureFileCopy@5
+            inputs:
+              SourcePath: '$(System.DefaultWorkingDirectory)/*'
+              azureSubscription: '$(TEST_AZURE_SUBSCRIPTION)'
+              Destination: 'AzureBlob'
+              storage: '$(TEST_STORAGE_ACCOUNT_NAME)'
+              ContainerName: '$(BLOB_CONTAINER_NAME)'
+              AdditionalArgumentsForBlobCopy: '--recursive --exclude-path "$(EXCLUDE_PATH)"'
+            displayName: Copy to container blob ($(TEST_STORAGE_ACCOUNT_NAME))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -44,7 +44,7 @@ parameters:
 
 variables:
   - name: BLOB_CONTAINER_NAME
-    value: '`$web'
+    value: '$web'
   - name: EXCLUDE_PATH
     value: 'README.md;CODEOWNERS;yarn.lock;package.json;azure-pipelines.yml;azure-templates;.node-version;.nvmrc;.prettierrc;jest.config.js;tsconfig.json;tslint.json;definitions;src;.circleci;.git;services-webview'
   - name: NODE_VERSION
@@ -123,7 +123,7 @@ stages:
       jobs:
         - job: publish_assets_prod
           steps:  
-            - task: AzureFileCopy@4
+            - task: AzureFileCopy@5
               inputs:
                 SourcePath: '$(System.DefaultWorkingDirectory)/*'
                 azureSubscription: '$(PRODUCTION_AZURE_SUBSCRIPTION)'


### PR DESCRIPTION
## Short description
Fix an issue where pipeline failed to copy data to storage account due to invalid characters as arguments

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
