### PR TITLE
[IOPID-1307] - Bump `min_app_version` for `emailUniquenessValidation`, `fastLogin` and `opt_in`

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -76,19 +76,19 @@
     },
     "emailUniquenessValidation": {
       "min_app_version": {
-        "ios": "2.49.0.0",
-        "android": "2.49.0.0"
+        "ios": "2.51.0.0",
+        "android": "2.51.0.0"
       }
     },
     "fastLogin": {
       "min_app_version": {
-        "ios": "2.39.0.1",
-        "android": "2.39.0.1"
+        "ios": "2.51.0.0",
+        "android": "2.51.0.0"
       },
       "opt_in": {
         "min_app_version": {
-          "ios": "2.46.0.1",
-          "android": "2.46.0.1"
+          "ios": "2.51.0.0",
+          "android": "2.51.0.0"
         }
       }
     },


### PR DESCRIPTION
## Short description
This PR bumps `min_app_version` for `emailUniquenessValidation`, `fastLogin` and `opt_in` to `2.51.0.0`.