### PR TITLE
feat: Add Bonus PC subcategory to Zendesk

### DIFF
--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -206,6 +206,13 @@
           "id": "8086481365265",
           "subCategories": [
             {
+              "value": "bonus_pc",
+              "description": {
+                "it-IT": "Bonus PC",
+                "en-EN": "Bonus PC"
+              }
+            },
+            {
               "value": "cashback",
               "description": {
                 "it-IT": "Cashback",


### PR DESCRIPTION
feat: Add Bonus PC subcategory to Zendesk

## Short description
Add Bonus PC subcategory under Bonus and Initiatives category. This is needed to open a new support request from app IO.