### PR TITLE
chore: [IOBP-696] Add payments section banner definitions

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -375,6 +375,8 @@ definitions:
         $ref: "#/definitions/SectionStatus"
       cdc:
         $ref: "#/definitions/SectionStatus"
+      payments:
+        $ref: "#/definitions/SectionStatus"
   SectionStatus:
     type: object
     description: The status of a specific app section

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.32",
+  "version": "1.0.33",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -213,7 +213,7 @@
     },
     "payments": {
       "is_visible": false,
-      "level": "crtical",
+      "level": "critical",
       "message": {
         "it-IT": "pagoPA non è al momento disponibile. I nostri tecnici sono al lavoro per risolvere il problema.",
         "en-EN": "pagoPA is currently not available. Our technicians are working to fix the issue."

--- a/status/backend.json
+++ b/status/backend.json
@@ -213,10 +213,10 @@
     },
     "payments": {
       "is_visible": false,
-      "level": "critical",
+      "level": "normal",
       "message": {
-        "it-IT": "pagoPA non è al momento disponibile. I nostri tecnici sono al lavoro per risolvere il problema.",
-        "en-EN": "pagoPA is currently not available. Our technicians are working to fix the issue."
+        "it-IT": "Stiamo riorganizzando i metodi di pagamento salvati in app.",
+        "en-EN": "We are rearranging the payment methods saved in the app."
       }
     },
     "ingress": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -211,6 +211,14 @@
         "en-EN": "pagoPA is currently not available. Our technicians are working to fix the issue."
       }
     },
+    "payments": {
+      "is_visible": false,
+      "level": "crtical",
+      "message": {
+        "it-IT": "pagoPA non è al momento disponibile. I nostri tecnici sono al lavoro per risolvere il problema.",
+        "en-EN": "pagoPA is currently not available. Our technicians are working to fix the issue."
+      }
+    },
     "ingress": {
       "is_visible": false,
       "level": "warning",

--- a/status/backend.json
+++ b/status/backend.json
@@ -214,6 +214,10 @@
     "payments": {
       "is_visible": false,
       "level": "normal",
+      "web_url": {
+        "it-IT": "https://io.italia.it/nuova-sezione-pagamenti",
+        "en-EN": "https://io.italia.it/nuova-sezione-pagamenti"
+      },
       "message": {
         "it-IT": "Stiamo riorganizzando i metodi di pagamento salvati in app.",
         "en-EN": "We are rearranging the payment methods saved in the app."


### PR DESCRIPTION
## Short description
This PR adds definitions and an initial implementation of the alert (formally called a banner) service to be displayed on the home payments page.

In this PR @thisisjp will insert the texts to be shown for this banner.

## List of changes proposed in this pull request
- Added definitions
- Upgraded package version
- Added a scaffolding structure for the payments banner section
