### PR TITLE
Enable banner on new payments page

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -216,7 +216,7 @@
       }
     },
     "payments": {
-      "is_visible": false,
+      "is_visible": true,
       "level": "normal",
       "web_url": {
         "it-IT": "https://io.italia.it/nuova-sezione-pagamenti",


### PR DESCRIPTION
This PR enables a disclaimer banner in the new payment page

