### PR TITLE
`fims.historyEnabled` flag in definitions.yml

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -546,6 +546,9 @@ definitions:
       domain:
         type: string
         description: "This is the url that will be used to store the session cookie inside the app dedicated webview"
+      historyEnabled:
+        type: boolean
+        description: "If true or undefined, FIMS history listItem will be shown in the profile/privacy section"
   AssistanceToolConfig:
     type: object
     description: "A specific config for the assistance tool"


### PR DESCRIPTION
## Short description
addition of said optional flag in `definitions.yml`, after it has been added to backendStatus in a previous PR

## List of changes proposed in this pull request
- addition of said flag


## How to test
tests should solve correctly
