### PR TITLE
chore: enable new wallet for `2.64.0.1`  only

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -71,8 +71,8 @@
     "newPaymentSection": {
       "enabled": false,
       "min_app_version": {
-        "ios": "2.63.0.5",
-        "android": "2.63.0.5"
+        "ios": "2.64.0.1",
+        "android": "2.64.0.1"
       }
     },
     "lollipop": {


### PR DESCRIPTION
## Short description
This PR enables new wallet for `2.64.0.1` only

