### PR TITLE
chore: enable new wallet section for 2.64.0.1 app version

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -71,8 +71,8 @@
     "newPaymentSection": {
       "enabled": false,
       "min_app_version": {
-        "ios": "3.0.0.0",
-        "android": "3.0.0.0"
+        "ios": "2.64.0.1",
+        "android": "2.64.0.1"
       }
     },
     "lollipop": {


### PR DESCRIPTION
## Short description
This PR enable the new wallet section feature flag for the app version `2.64.0.1`
