### PR TITLE
chore: disable new wallet section payment feature flag

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -71,8 +71,8 @@
     "newPaymentSection": {
       "enabled": false,
       "min_app_version": {
-        "ios": "3.0.0.0",
-        "android": "3.0.0.0"
+        "ios": "2.64.0.1",
+        "android": "2.64.0.1"
       }
     },
     "lollipop": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -71,8 +71,8 @@
     "newPaymentSection": {
       "enabled": false,
       "min_app_version": {
-        "ios": "2.64.0.1",
-        "android": "2.64.0.1"
+        "ios": "3.0.0.0",
+        "android": "3.0.0.0"
       }
     },
     "lollipop": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -71,8 +71,8 @@
     "newPaymentSection": {
       "enabled": false,
       "min_app_version": {
-        "ios": "2.63.0.5",
-        "android": "2.63.0.5"
+        "ios": "3.0.0.0",
+        "android": "3.0.0.0"
       }
     },
     "lollipop": {


### PR DESCRIPTION
## This PR depends on #801 

## Short description
This PR sets the min app version to the new payment section feature flag to `3.0.0.0` in order to disable it.