### PR TITLE
Update payments banners

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -215,24 +215,24 @@
       "is_visible": true,
       "level": "warning",
       "web_url": {
-        "it-IT": "https://io.italia.it/nuova-sezione-pagamenti",
-        "en-EN": "https://io.italia.it/nuova-sezione-pagamenti"
+        "it-IT": "https://io.italia.it/nuova-sezione-pagamenti-legacy",
+        "en-EN": "https://io.italia.it/nuova-sezione-pagamenti-legacy"
       },
       "message": {
-        "it-IT": "Aggiorna IO all'ultima versione disponibile.",
-        "en-EN": "Update IO to the latest version available."
+        "it-IT": "Aggiorna IO e accedi alle tue ricevute dalla nuova sezione Pagamenti.",
+        "en-EN": "Update IO and get access to your receipts using the new Payments section."
       }
     },
     "payments": {
       "is_visible": true,
       "level": "normal",
       "web_url": {
-        "it-IT": "https://io.italia.it/nuova-sezione-pagamenti",
-        "en-EN": "https://io.italia.it/nuova-sezione-pagamenti"
+        "it-IT": "https://io.italia.it/nuova-sezione-pagamenti-istruzioni",
+        "en-EN": "https://io.italia.it/nuova-sezione-pagamenti-istruzioni"
       },
       "message": {
-        "it-IT": "Stiamo riorganizzando i metodi di pagamento salvati in app.",
-        "en-EN": "We are rearranging the payment methods saved in the app."
+        "it-IT": "Se vuoi pagare con carta o PayPal, aggiungili prima al tuo Portafoglio.",
+        "en-EN": "To pay with card or PayPal, make sure they're already in your Wallet."
       }
     },
     "ingress": {


### PR DESCRIPTION
> [!WARNING]
> This PR depends on: https://github.com/pagopa/io.italia.it/pull/535


- Users with v <2.65.0.0 will see a banner in Wallet page engaging them to update the app to the latest version, with a new dedicated URL
- Users with v >= 2.65.0.0 will see a banner in Payments page to explain how to pay with card or PayPal, with a new dedicated URL

![Banner per utenti PayPall e carte](https://github.com/user-attachments/assets/400c1914-4191-4d3b-9790-1022579600b9)
![Banner utenti legacy](https://github.com/user-attachments/assets/41c0d88f-84f6-4a7a-9a51-09fee51a6c9e)
