### PR TITLE
Fix wrong route in FAQ

### DIFF
--- a/contextualhelp/data.json
+++ b/contextualhelp/data.json
@@ -667,7 +667,7 @@
         ]
       },
       {
-        "route_name": "PAYMENT_HOME",
+        "route_name": "PAYMENTS_HOME",
         "title": "Cosa puoi fare nella sezione Pagamenti",
         "content": "Qui puoi pagare un avviso, vedere le ricevute di pagamento pagoPA e aggiungere un metodo di pagamento",
         "faqs": [


### PR DESCRIPTION
This PR fixes a typo in the FAQ json file (`PAYMENT_HOME` instead of the correct one `PAYMENTS_HOME`) 