### PR TITLE
Modify payments banner

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -231,8 +231,8 @@
         "en-EN": "https://io.italia.it/nuova-sezione-pagamenti-istruzioni"
       },
       "message": {
-        "it-IT": "Se vuoi pagare con carta o PayPal, aggiungili prima al tuo Portafoglio.",
-        "en-EN": "To pay with card or PayPal, make sure they're already in your Wallet."
+        "it-IT": "Se vuoi pagare con carta, aggiungila prima al tuo Portafoglio.",
+        "en-EN": "To pay with card, make sure it's already in your Wallet."
       }
     },
     "ingress": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -225,7 +225,7 @@
     },
     "payments": {
       "is_visible": true,
-      "level": "normal",
+      "level": "warning",
       "web_url": {
         "it-IT": "https://io.italia.it/nuova-sezione-pagamenti-istruzioni",
         "en-EN": "https://io.italia.it/nuova-sezione-pagamenti-istruzioni"


### PR DESCRIPTION
This PR slightly changes the banner visibile in payments section:
- removed references to PayPal
- changed level from normal to warning, to boost users engagement