### PR TITLE
[IOPID-2049] Add remote FF of sessionRefresh after two minutes in background 

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -765,7 +765,13 @@ definitions:
       sessionRefresh:
         type: object
         description: "A configuration for the fast login session refresh after two minutes of inactivity"
+        required:
+          - enabled
+          - min_app_version
         properties:
+          enabled:
+            type: boolean
+            description: "If true, after at least two minutes that the app is in the background, when the app returns to the foreground, the session is refreshed"
           min_app_version:
             $ref: "#/definitions/VersionPerPlatform"
             description: "If min app version supported, the fast login session refresh feature is enabled"

--- a/definitions.yml
+++ b/definitions.yml
@@ -762,6 +762,13 @@ definitions:
           min_app_version:
             $ref: "#/definitions/VersionPerPlatform"
             description: "If min app version supported, the fast login opt-in feature is enabled"
+      sessionRefresh:
+        type: object
+        description: "A configuration for the fast login session refresh after two minutes of inactivity"
+        properties:
+          min_app_version:
+            $ref: "#/definitions/VersionPerPlatform"
+            description: "If min app version supported, the fast login session refresh feature is enabled"
   NativeLoginConfig:
     type: object
     description: "A configuration to let users authenticate through native components"    

--- a/definitions.yml
+++ b/definitions.yml
@@ -765,13 +765,7 @@ definitions:
       sessionRefresh:
         type: object
         description: "A configuration for the fast login session refresh after two minutes of inactivity"
-        required:
-          - enabled
-          - min_app_version
         properties:
-          enabled:
-            type: boolean
-            description: "If true, after at least two minutes that the app is in the background, when the app returns to the foreground, the session is refreshed"
           min_app_version:
             $ref: "#/definitions/VersionPerPlatform"
             description: "If min app version supported, the fast login session refresh feature is enabled"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.35",
+  "version": "1.0.36",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.34",
+  "version": "1.0.35",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -100,7 +100,6 @@
         }
       },
       "sessionRefresh": {
-        "enabled": false,
         "min_app_version": {
           "ios": "0.0.0.0",
           "android": "0.0.0.0"

--- a/status/backend.json
+++ b/status/backend.json
@@ -98,6 +98,13 @@
           "ios": "2.51.0.0",
           "android": "2.51.0.0"
         }
+      },
+      "sessionRefresh": {
+        "enabled": false,
+        "min_app_version": {
+          "ios": "0.0.0.0",
+          "android": "0.0.0.0"
+        }
       }
     },
     "pn": {


### PR DESCRIPTION
## Short description
This PR adds a remote feature flag to the sessionRefresh feature. If this new remote FF is enabled, after at least 2 minutes of app background, when the app back in foreground, the token will be automatically refreshed 

## List of changes proposed in this pull request
- Add the `sessionRefresh` attribute to the backend.json 
- Added the model definitions from the open API specs (into the fastLogin object);
- Upgraded the package.json version (align version in package.json with released version)

