### PR TITLE
[IOCOM-1649] Proper structure for FIMS `min_app_version`

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -561,7 +561,7 @@ definitions:
         description: "If true or undefined, FIMS history listItem will be shown in the profile/privacy section"
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"
-        description: "If min app version supported, the single sign-on flow can be used"
+        description: "If min app version supported, FIMS SSO is enabled"
 
   AssistanceToolConfig:
     type: object

--- a/definitions.yml
+++ b/definitions.yml
@@ -559,13 +559,9 @@ definitions:
       historyEnabled:
         type: boolean
         description: "If true or undefined, FIMS history listItem will be shown in the profile/privacy section"
-      singleSignOn:
-        type: object
-        description: "A configuration for the FIMS single sign-on flow"
-        properties:
-          min_app_version:
-            $ref: "#/definitions/VersionPerPlatform"
-            description: "If min app version supported, the single sign-on flow can be used"
+      min_app_version:
+        $ref: "#/definitions/VersionPerPlatform"
+        description: "If min app version supported, the single sign-on flow can be used"
 
   AssistanceToolConfig:
     type: object

--- a/status/backend.json
+++ b/status/backend.json
@@ -35,17 +35,15 @@
       "enabled": false,
       "history": {
         "min_app_version": {
-          "ios": "2.67.0.3",
-          "android": "2.67.0.3"
+          "ios": "2.68.0.0",
+          "android": "2.68.0.0"
         }
       },
       "historyEnabled": false,
-      "singleSignOn": {
-        "min_app_version": {
-          "ios": "2.67.0.3",
-          "android": "2.67.0.3"
+      "min_app_version": {
+          "ios": "2.68.0.0",
+          "android": "2.68.0.0"
         }
-      }
     },
     "uaDonations": {
       "enabled": false,


### PR DESCRIPTION
## Short description
This PR fixes the `min_app_version` for FIMS in order to use IO-App helpers functions.

## List of changes proposed in this pull request
- `min_app_version` promoted to top level property in `fims` configuration

## How to test
Static checks should succeed.
