### PR TITLE
[IOCOM-1680] Remove `min_app_version` from FIMS history

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -549,13 +549,6 @@ definitions:
       enabled:
         type: boolean
         description: "This is a legacy property that must remain here in order not to break compatibility. It is not used anymore"
-      history:
-        type: object
-        description: "A configuration for the FIMS history feature"
-        properties:
-          min_app_version:
-            $ref: "#/definitions/VersionPerPlatform"
-            description: "If min app version supported, the FIMS history section can be used"
       historyEnabled:
         type: boolean
         description: "If true or undefined, FIMS history listItem will be shown in the profile/privacy section"

--- a/status/backend.json
+++ b/status/backend.json
@@ -33,12 +33,6 @@
     "fims": {
       "domain": "https://oauth.io.pagopa.it/",
       "enabled": false,
-      "history": {
-        "min_app_version": {
-          "ios": "2.68.0.0",
-          "android": "2.68.0.0"
-        }
-      },
       "historyEnabled": false,
       "min_app_version": {
           "ios": "2.68.0.0",


### PR DESCRIPTION
## Short description
This PR removes the `min_app_version` from FIMS history, so only the main `min_app_version` under `fims` will be used.

## List of changes proposed in this pull request
- `min_app_version`and FIMS `history` removed
 
## How to test
Static checks should succeed.
