### PR TITLE
feat: add new categories for Documenti su IO

### DIFF
--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -86,7 +86,7 @@
               "value": "it_wallet_tessera_sanitaria",
               "description": {
                 "it-IT": "Ho un problema con la Tessera Sanitaria",
-                "en-EN": "Ho un problema con la Tessera Sanitaria",
+                "en-EN": "I have an issue with the Health Insurance Card",
                 "de-DE": "Ich habe ein Problem mit der Gesundheitskarte"
               }
             },

--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -54,7 +54,7 @@
               "value": "it_wallet_info",
               "description": {
                 "it-IT": "Vorrei più informazioni",
-                "en-EN": "Vorrei più informazioni",
+                "en-EN": "I need more details",
                 "de-DE": "Weitere Informationen erhalten"
               }
             },
@@ -78,7 +78,7 @@
               "value": "it_wallet_patente_guida",
               "description": {
                 "it-IT": "Ho un problema con la Patente di Guida",
-                "en-EN": "Ho un problema con la Patente di Guida",
+                "en-EN": "I have an issue with the Driving Licence",
                 "de-DE": "Ich habe ein Problem mit dem Führerschein"
               }
             },
@@ -94,7 +94,7 @@
               "value": "it_wallet_carta_disabilita",
               "description": {
                 "it-IT": "Ho un problema con la Carta Europea della Disabilità",
-                "en-EN": "Ho un problema con la Carta Europea della Disabilità",
+                "en-EN": "I have an issue with the European Disability Card",
                 "de-DE": "Ich habe ein Problem mit dem Europäischen Behindertenausweis"
               }
             }
@@ -237,7 +237,7 @@
               "value": "firma_informazioni_generali",
               "description": {
                 "it-IT": "Vorrei più informazioni",
-                "en-EN": "I'd like to have more information",
+                "en-EN": "I need more details",
                 "de-DE": "Weitere Informationen erhalten"
               }
             }
@@ -274,7 +274,7 @@
               "value": "informazioni_generali",
               "description": {
                 "it-IT": "Vorrei più informazioni",
-                "en-EN": "I would like to have more information",
+                "en-EN": "I need more details",
                 "de-DE": "Weitere Informationen erhalten"
               }
             }

--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -45,7 +45,7 @@
         "description": {
           "it-IT": "Documenti su IO",
           "en-EN": "Documenti su IO",
-          "de-DE": "Documenti su IO"
+          "de-DE": "Dokumente in IO"
         },
         "zendeskSubCategories": {
           "id": "29326690756369",
@@ -55,7 +55,7 @@
               "description": {
                 "it-IT": "Vorrei più informazioni",
                 "en-EN": "Vorrei più informazioni",
-                "de-DE": "Vorrei più informazioni"
+                "de-DE": "Weitere Informationen erhalten"
               }
             },
             {
@@ -63,7 +63,7 @@
               "description": {
                 "it-IT": "Documenti su IO non è attiva per me",
                 "en-EN": "Documenti su IO non è attiva per me",
-                "de-DE": "Documenti su IO non è attiva per me"
+                "de-DE": "Dokumente in IO ist für mich nicht aktiv"
               }
             },
             {
@@ -71,7 +71,7 @@
               "description": {
                 "it-IT": "Non riesco ad aggiungere i documenti",
                 "en-EN": "Non riesco ad aggiungere i documenti",
-                "de-DE": "Non riesco ad aggiungere i documenti"
+                "de-DE": "Ich kann keine Dokumente hinzufügen"
               }
             },
             {
@@ -79,7 +79,7 @@
               "description": {
                 "it-IT": "Ho un problema con la Patente di Guida",
                 "en-EN": "Ho un problema con la Patente di Guida",
-                "de-DE": "Ho un problema con la Patente di Guida"
+                "de-DE": "Ich habe ein Problem mit dem Führerschein"
               }
             },
             {
@@ -87,7 +87,7 @@
               "description": {
                 "it-IT": "Ho un problema con la Tessera Sanitaria",
                 "en-EN": "Ho un problema con la Tessera Sanitaria",
-                "de-DE": "Ho un problema con la Tessera Sanitaria"
+                "de-DE": "Ich habe ein Problem mit der Gesundheitskarte"
               }
             },
             {
@@ -95,7 +95,7 @@
               "description": {
                 "it-IT": "Ho un problema con la Carta Europea della Disabilità",
                 "en-EN": "Ho un problema con la Carta Europea della Disabilità",
-                "de-DE": "Ho un problema con la Carta Europea della Disabilità"
+                "de-DE": "Ich habe ein Problem mit dem Europäischen Behindertenausweis"
               }
             }
           ]
@@ -238,7 +238,7 @@
               "description": {
                 "it-IT": "Vorrei più informazioni",
                 "en-EN": "I'd like to have more information",
-                "de-DE": "Zusätzliche Informationen"
+                "de-DE": "Weitere Informationen erhalten"
               }
             }
           ]
@@ -275,7 +275,7 @@
               "description": {
                 "it-IT": "Vorrei più informazioni",
                 "en-EN": "I would like to have more information",
-                "de-DE": "Weitere Informationen"
+                "de-DE": "Weitere Informationen erhalten"
               }
             }
           ]

--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -41,6 +41,67 @@
         }
       },
       {
+        "value": "it_wallet",
+        "description": {
+          "it-IT": "Documenti su IO",
+          "en-EN": "Documenti su IO",
+          "de-DE": "Documenti su IO"
+        },
+        "zendeskSubCategories": {
+          "id": "29326690756369",
+          "subCategories": [
+            {
+              "value": "it_wallet_info",
+              "description": {
+                "it-IT": "Vorrei più informazioni",
+                "en-EN": "Vorrei più informazioni",
+                "de-DE": "Vorrei più informazioni"
+              }
+            },
+            {
+              "value": "it_wallet_attivazione",
+              "description": {
+                "it-IT": "Documenti su IO non è attiva per me",
+                "en-EN": "Documenti su IO non è attiva per me",
+                "de-DE": "Documenti su IO non è attiva per me"
+              }
+            },
+            {
+              "value": "it_wallet_aggiunta_documenti",
+              "description": {
+                "it-IT": "Non riesco ad aggiungere i documenti",
+                "en-EN": "Non riesco ad aggiungere i documenti",
+                "de-DE": "Non riesco ad aggiungere i documenti"
+              }
+            },
+            {
+              "value": "it_wallet_patente_guida",
+              "description": {
+                "it-IT": "Ho un problema con la Patente di Guida",
+                "en-EN": "Ho un problema con la Patente di Guida",
+                "de-DE": "Ho un problema con la Patente di Guida"
+              }
+            },
+            {
+              "value": "it_wallet_tessera_sanitaria",
+              "description": {
+                "it-IT": "Ho un problema con la Tessera Sanitaria",
+                "en-EN": "Ho un problema con la Tessera Sanitaria",
+                "de-DE": "Ho un problema con la Tessera Sanitaria"
+              }
+            },
+            {
+              "value": "it_wallet_carta_disabilita",
+              "description": {
+                "it-IT": "Ho un problema con la Carta Europea della Disabilità",
+                "en-EN": "Ho un problema con la Carta Europea della Disabilità",
+                "de-DE": "Ho un problema con la Carta Europea della Disabilità"
+              }
+            }
+          ]
+        }
+      },
+      {
         "value": "pagamenti_pagopa",
         "description": {
           "it-IT": "Pagamento pagoPA",


### PR DESCRIPTION
## Short description
Add a new category "Documenti su IO" and 6 sub-categories.

## List of changes proposed in this pull request
- Add a new category "Documenti su IO" and 6 sub-categories. Note that English and German labels will be provided later by Product & Design team.

## How to test
In app IO you need to click on '?' and create a new service request. Select "Documenti su IO" and one of its sub-categories.
