### PR TITLE
fix: [IOBP-961] Add missing german key for FAQ

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -645,10 +645,13 @@ definitions:
     required:
       - it-IT
       - en-EN
+      - de-DE
     properties:
       it-IT:
         type: string
       en-EN:
+        type: string
+      de-DE:
         type: string
   ZendeskCategory:
     type: object


### PR DESCRIPTION
## Short description
This pull request includes a small change to the `definitions.yml` file. The change adds support for the German language (`de-DE`) in the `definitions` section for FAQ
