### PR TITLE
[SIW–1877] Bump `min_app_version` from `2.68.0.0` to `2.77.0.3`

### DIFF
--- a/status/versionInfo.json
+++ b/status/versionInfo.json
@@ -1,7 +1,7 @@
 {
   "min_app_version": {
-    "ios": "2.68.0.0",
-    "android": "2.68.0.0"
+    "ios": "2.77.0.3",
+    "android": "2.77.0.3"
   },
   "min_app_version_pagopa": {
     "ios": "0.0.0",


### PR DESCRIPTION
This PR bumps the `min_app_version` from `2.68.0.0` to `2.77.0.3`
