### PR TITLE
chore: [IOBP-996] Enable qualtrics payment feedback banner

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -80,8 +80,8 @@
       },
       "feedbackBanner": {
         "min_app_version": {
-          "ios": "3.0.0.0",
-          "android": "3.0.0.0"
+          "ios": "2.65.0.0",
+          "android": "2.65.0.0"
         },
         "title": {
           "it-IT": "Puoi dirci com'è andata?",
@@ -96,7 +96,7 @@
             "it-IT": "Vai al sondaggio",
             "en-EN": "Go to survey"
           },
-          "url": "https://io.italia.it/diccilatua/ces-pagamento"
+          "url": "https://pagopa.qualtrics.com/jfe/form/SV_0GmGr2F3vt8oaZE"
         }
       }
     },


### PR DESCRIPTION
## Short description
This PR enables the feedback banner showed when the user completes a payment, adding the qualtrics survey link.

## List of changes proposed in this pull request
- Added the min version to show this banner;
- Added the qualtrics survey link to the CTA of the banner;
