### PR TITLE
[SIW-1922] Bump `min_app_version` from `2.77.0.3` to `2.78.0.11`

### DIFF
--- a/status/versionInfo.json
+++ b/status/versionInfo.json
@@ -1,7 +1,7 @@
 {
   "min_app_version": {
-    "ios": "2.77.0.3",
-    "android": "2.77.0.3"
+    "ios": "2.78.0.11",
+    "android": "2.78.0.11"
   },
   "min_app_version_pagopa": {
     "ios": "0.0.0",


### PR DESCRIPTION
> [!NOTE]
> The merge of this PR is scheduled for **18th December 2024**

## Short description
This PR bumps the min app version required to run the IO App. 

## List of changes proposed in this pull request
- Bumped `min_app_version` from `2.77.0.3` to `2.78.0.11` 

## How to test
Static checks should pass
