### PR TITLE
remove/move old categories

### DIFF
--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -330,72 +330,6 @@
         }
       },
       {
-        "value": "firma_con_io",
-        "description": {
-          "it-IT": "Firma con IO",
-          "en-EN": "Firma con IO",
-          "de-DE": "Mit IO unterschreiben"
-        },
-        "zendeskSubCategories": {
-          "id": "14506152434193",
-          "subCategories": [
-            {
-              "value": "firma_problemi_tecnici_su_io",
-              "description": {
-                "it-IT": "Ho un problema con IO",
-                "en-EN": "I have an issue with IO",
-                "de-DE": "Technisches Problem mit IO"
-              }
-            },
-            {
-              "value": "firma_informazioni_generali",
-              "description": {
-                "it-IT": "Vorrei più informazioni",
-                "en-EN": "I need more details",
-                "de-DE": "Weitere Informationen erhalten"
-              }
-            }
-          ]
-        }
-      },
-      {
-        "value": "certificazione_verde_covid-19",
-        "description": {
-          "it-IT": "Certificazione Verde COVID-19",
-          "en-EN": "EU Digital COVID Certificate",
-          "de-DE": "Grünes EU COVID Zertifikat"
-        },
-        "zendeskSubCategories": {
-          "id": "360029178738",
-          "subCategories": [
-            {
-              "value": "non_ho_ricevuto_nulla",
-              "description": {
-                "it-IT": "Non ho ricevuto la Certificazione",
-                "en-EN": "I haven't received the Certificate",
-                "de-DE": "Zertifikat nicht erhalten"
-              }
-            },
-            {
-              "value": "problemi_tecnici_su_io",
-              "description": {
-                "it-IT": "Ho un problema con IO",
-                "en-EN": "I have a problem with IO",
-                "de-DE": "Technisches Problem mit IO"
-              }
-            },
-            {
-              "value": "informazioni_generali",
-              "description": {
-                "it-IT": "Vorrei più informazioni",
-                "en-EN": "I need more details",
-                "de-DE": "Weitere Informationen erhalten"
-              }
-            }
-          ]
-        }
-      },
-      {
         "value": "bonus_e_iniziative",
         "description": {
           "it-IT": "Bonus e iniziative",
@@ -428,6 +362,14 @@
                 "en-EN": "Bonus Vacanze",
                 "de-DE": "Ferienbonus"
               }
+            },
+            {
+              "value": "firma_con_io",
+              "description": {
+                "it-IT": "Firma con IO",
+                "en-EN": "Firma con IO",
+                "de-DE": "Mit IO unterschreiben"
+              }
             }
           ]
         }
@@ -456,6 +398,14 @@
                 "it-IT": "Accessibilità e Usabilità",
                 "en-EN": "Accessibility and Usability",
                 "de-DE": "Barrierefreiheit und Benutzerfreundlichkeit"
+              }
+            },
+            {
+              "value": "certificazione_verde_covid-19",
+              "description": {
+                "it-IT": "Certificazione Verde COVID-19",
+                "en-EN": "EU Digital COVID Certificate",
+                "de-DE": "Grünes EU COVID Zertifikat"
               }
             },
             {


### PR DESCRIPTION
## Short description
Firma and COVID-Cert categories are partially deprecated

## List of changes proposed in this pull request
- Remove category-tree for "Firma con IO"
- Remove category-tree for "Certificato COVID-19"
- Add "Firma con IO" as a second level category in "Bonus"
- Add "Certificato COVID-19" as a second level category in "Nessuno dei precedenti".