### PR TITLE
FIMS min app version to 2.79.0.9 (iPatente and internal RP support)

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -35,8 +35,8 @@
       "enabled": false,
       "historyEnabled": true,
       "min_app_version": {
-          "ios": "2.77.1.0",
-          "android": "2.77.1.0"
+          "ios": "2.79.0.9",
+          "android": "2.79.0.9"
         }
     },
     "uaDonations": {


### PR DESCRIPTION
## Short description
FIMS min app version to 2.7.9.0.9 in order to support internal Relying Parties.