### PR TITLE
[SIW-1919] Add iPatente MDL details screen CTA feature flag

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -946,6 +946,7 @@ definitions:
       - min_app_version
       - enabled
       - feedback_banner_visible
+      - ipatente_cta_visible
     properties:
       enabled:
         type: boolean
@@ -983,6 +984,9 @@ definitions:
           description:
             $ref: "#/definitions/LocalizedText"
             description: "The description to be shown in screen"
+      ipatente_cta_visible:
+        description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
+        type: boolean
   Banner:
     type: object
     required:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.51",
+  "version": "1.0.52",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -149,7 +149,8 @@
         "ios": "2.67.0.2",
         "android": "2.67.0.2"
       },
-      "feedback_banner_visible": true
+      "feedback_banner_visible": true,
+      "ipatente_cta_visible": true
     },
     "cie_id": {
       "min_app_version": {


### PR DESCRIPTION
## Short description
This PR adds the remote FF for the iPatente CTA inside the MDL details screen

## List of changes proposed in this pull request
- Added **required** `ipatente_cta_visible` property in the `ItwConfig`
- Add `ipatente_cta_visible: true` in `status/backend.json`
- Bumped version to `1.0.52`

## How to test
Static checks should pass
