### PR TITLE
Update the sha value in workflow in order to publish cdn

### DIFF
--- a/.github/workflows/publish_cdn.yml
+++ b/.github/workflows/publish_cdn.yml
@@ -65,7 +65,7 @@ jobs:
               --recursive
      
       - name: Purge CDN endpoint
-        uses: azure/CLI@b0e31ae20280d899279f14c36e877b4c6916e2d3
+        uses: azure/CLI@ce5a2f60a82a531970a546cb97b6bf93b64fb9d3
         with:
           inlineScript: |
             az cdn endpoint purge \


### PR DESCRIPTION
## Short description
As suggested by @Krusty93, in this PR I update the value of the sha in the workflow file that allows the deployment of the CDN