### PR TITLE
fix: Update the sha value in workflow in order to publish cdn

### DIFF
--- a/.github/workflows/publish_cdn.yml
+++ b/.github/workflows/publish_cdn.yml
@@ -50,7 +50,7 @@ jobs:
 
       - name: Upload to blob storage
         id: storage_upload
-        uses: azure/CLI@b0e31ae20280d899279f14c36e877b4c6916e2d3
+        uses: azure/CLI@ce5a2f60a82a531970a546cb97b6bf93b64fb9d3
         with:
           inlineScript: |
             # workaround to escape dollar sign


### PR DESCRIPTION
> [!Warning] 
> This PR is a fix of this PR https://github.com/pagopa/io-services-metadata/pull/917
## Short description
As suggested by @Krusty93, in this PR I update the value of the sha in the workflow file that allows the deployment of the CDN. 
