### PR TITLE
[SIW-1953] Add iPatente CTA property in ItwConfig

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -1002,7 +1002,7 @@ definitions:
             $ref: "#/definitions/LocalizedText"
             description: "The description to be shown in screen"
       ipatente_cta:
-        description: "Information about the iPatente CTA"
+        description: "Information about the iPatente CTA inside the MDL credential details screen"
         type: object
         properties:
           visibility:

--- a/definitions.yml
+++ b/definitions.yml
@@ -964,7 +964,6 @@ definitions:
       - min_app_version
       - enabled
       - feedback_banner_visible
-      - ipatente_cta_visible
     properties:
       enabled:
         type: boolean
@@ -1002,9 +1001,25 @@ definitions:
           description:
             $ref: "#/definitions/LocalizedText"
             description: "The description to be shown in screen"
-      ipatente_cta_visible:
-        description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
-        type: boolean
+      ipatente_cta:
+        description: "Information about the iPatente CTA"
+        type: object
+        properties:
+          visibility:
+            type: boolean
+            description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
+          service_id:
+            type: string
+            description: "The serviceId of the iPatente service"
+          service_name:
+            type: string
+            description: "The service name of the iPatente service"
+          service_organization_name: 
+            type: string
+            description: "The name of the organization of the iPatente service"
+          service_organization_fiscal_code:
+            type: string
+            description: "The fiscal code of the organization of the iPatente service"
   Banner:
     type: object
     required:

--- a/definitions.yml
+++ b/definitions.yml
@@ -1004,10 +1004,17 @@ definitions:
       ipatente_cta:
         description: "Information about the iPatente CTA inside the MDL credential details screen"
         type: object
+        required:
+          - visibility
+          - service_id
+          - url
         properties:
           visibility:
             type: boolean
             description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
+          url:
+            type: string
+            description: "The URL that must be loaded when the iPatente CTA inside the MDL details screen is tapped"
           service_id:
             type: string
             description: "The serviceId of the iPatente service"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -161,6 +161,7 @@
       "feedback_banner_visible": true,
       "ipatente_cta": {
         "visibility": true,
+        "url": "https://licences.ipatente.io.pagopa.it/licences",
         "service_id": "01JEXVQSRV2XRX9XDWQ5XQ6A8T",
         "service_name": "Motorizzazione Civile - Le mie patenti",
         "service_organization_name": "Ministero delle infrastrutture e dei trasporti",

--- a/status/backend.json
+++ b/status/backend.json
@@ -159,7 +159,13 @@
         "android": "2.67.0.2"
       },
       "feedback_banner_visible": true,
-      "ipatente_cta_visible": true
+      "ipatente_cta": {
+        "visibility": true,
+        "service_id": "01JEXVQSRV2XRX9XDWQ5XQ6A8T",
+        "service_name": "Motorizzazione Civile - Le mie patenti",
+        "service_organization_name": "Ministero delle infrastrutture e dei trasporti",
+        "service_organization_fiscal_code": "97532760580"
+      }
     },
     "cie_id": {
       "min_app_version": {


### PR DESCRIPTION
## Short description
This PR creates the `ipatente_cta` object to handle the visibility and tracking details of the iPatente service.

## List of changes proposed in this pull request
- Deleted `ipatente_cta_visible` property in ItwConfig
- Added the `ipatente_cta` object and added to `status/backend.json `
- Bumped version to `1.0.56`

