### PR TITLE
fix: Add workaround to deploy cdn

### DIFF
--- a/.github/workflows/publish_cdn.yml
+++ b/.github/workflows/publish_cdn.yml
@@ -53,6 +53,7 @@ jobs:
         uses: azure/CLI@ce5a2f60a82a531970a546cb97b6bf93b64fb9d3
         with:
           inlineScript: |
+            tdnf install -y azcopy-10.15.0
             # workaround to escape dollar sign
             container='$web'
 


### PR DESCRIPTION
## Short description
In order to deploy the CDN and not receive the error you see in [these deployment attempts](https://github.com/pagopa/io-services-metadata/actions/runs/12785222306), this command line was added to the deploy configuration file 

