### PR TITLE
fix: change azcopy version

### DIFF
--- a/.github/workflows/publish_cdn.yml
+++ b/.github/workflows/publish_cdn.yml
@@ -53,7 +53,7 @@ jobs:
         uses: azure/CLI@ce5a2f60a82a531970a546cb97b6bf93b64fb9d3
         with:
           inlineScript: |
-            tdnf install -y azcopy-10.15.0
+            tdnf install -y azcopy-10.24.0
             # workaround to escape dollar sign
             container='$web'
 


### PR DESCRIPTION
## Short description
This PR is a fix of this PR https://github.com/pagopa/io-services-metadata/pull/920 and change the version of azcopy 

