### PR TITLE
[SIW-1953] Add iPatente CTA property in ItwConfig

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -1015,7 +1015,7 @@ definitions:
         properties:
           visibility:
             type: boolean
-            description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
+            description: "Manages the visibility of the iPatente CTA inside the MDL details screen"
           url:
             type: string
             description: "The URL that must be loaded when the iPatente CTA inside the MDL details screen is tapped"

--- a/definitions.yml
+++ b/definitions.yml
@@ -1006,18 +1006,22 @@ definitions:
         description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
         type: boolean
       ipatente_cta_config:
-        description: "Config about the iPatente CTA inside the MDL credential details screen"
+        description: "Config for iPatente CTA inside the MDL credential details screen"
         type: object
         required:
+          - visibility
           - service_id
           - url
         properties:
+          visibility:
+            type: boolean
+            description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
           url:
             type: string
             description: "The URL that must be loaded when the iPatente CTA inside the MDL details screen is tapped"
           service_id:
             type: string
-            description: "The serviceId of the iPatente service"
+            description: "The service id of the iPatente service"
           service_name:
             type: string
             description: "The service name of the iPatente service"

--- a/definitions.yml
+++ b/definitions.yml
@@ -1005,6 +1005,28 @@ definitions:
       ipatente_cta_visible:
         description: "Manages the visibility of the iPatente service CTA inside the MDL details screen"
         type: boolean
+      ipatente_cta_config:
+        description: "Config about the iPatente CTA inside the MDL credential details screen"
+        type: object
+        required:
+          - service_id
+          - url
+        properties:
+          url:
+            type: string
+            description: "The URL that must be loaded when the iPatente CTA inside the MDL details screen is tapped"
+          service_id:
+            type: string
+            description: "The serviceId of the iPatente service"
+          service_name:
+            type: string
+            description: "The service name of the iPatente service"
+          service_organization_name: 
+            type: string
+            description: "The name of the organization of the iPatente service"
+          service_organization_fiscal_code:
+            type: string
+            description: "The fiscal code of the organization of the iPatente service"
   Banner:
     type: object
     required:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.55",
+  "version": "1.0.56",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -159,7 +159,14 @@
         "android": "2.67.0.2"
       },
       "feedback_banner_visible": true,
-      "ipatente_cta_visible": true
+      "ipatente_cta_visible": true,
+      "ipatente_cta_config": {
+        "url": "https://licences.ipatente.io.pagopa.it/licences",
+        "service_id": "01JEXVQSRV2XRX9XDWQ5XQ6A8T",
+        "service_name": "Motorizzazione Civile - Le mie patenti",
+        "service_organization_name": "Ministero delle infrastrutture e dei trasporti",
+        "service_organization_fiscal_code": "97532760580"
+      }
     },
     "cie_id": {
       "min_app_version": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -161,6 +161,7 @@
       "feedback_banner_visible": true,
       "ipatente_cta_visible": true,
       "ipatente_cta_config": {
+        "visibility": true,
         "url": "https://licences.ipatente.io.pagopa.it/licences",
         "service_id": "01JEXVQSRV2XRX9XDWQ5XQ6A8T",
         "service_name": "Motorizzazione Civile - Le mie patenti",


### PR DESCRIPTION
## Short description
This PR creates the `ipatente_cta_config` object to handle the URL that must be loaded and the tracking details of the `iPatente` service.

## List of changes proposed in this pull request
- Added the `ipatente_cta_config` object and added to `status/backend.json `
- Bumped version to `1.0.56`
