### PR TITLE
[PE-863] Enable CGN short maintenance banner warning

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -176,7 +176,18 @@
     }
   },
   "statusMessages": {
-    "items": []
+    "items": [
+      {
+        "routes": ["CGN_CATEGORIES", "CGN_CATEGORIES_ALL"],
+        "level": "warning",
+        "message": {
+          "it-IT":
+            "La sezione è in manutenzione, alcuni partner torneranno operativi a breve.",
+          "en-EN":
+            "The section is under maintenance; some partners will resume service shortly."
+        }
+      }
+    ]
   },
   "sections": {
     "email_validation": {


### PR DESCRIPTION
# 🕦 Scheduled merge on 20th January 2025 9:15 AM

## Short description
This PR enables a warning banner with a text about a **short** maintenance on the CGN screens: `CGN_CATEGORIES` and `CGN_MERCHANTS_ALL`

## List of changes proposed in this pull request
- Added a status message of warning level to the routes `CGN_CATEGORIES` and `CGN_MERCHANTS_ALL`..
