### PR TITLE
[PE-863] Enable CGN banner long maintenance warning

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -176,7 +176,18 @@
     }
   },
   "statusMessages": {
-    "items": []
+    "items": [
+      {
+        "routes": ["CGN_CATEGORIES", "CGN_CATEGORIES_ALL"],
+        "level": "warning",
+        "message": {
+          "it-IT":
+            "La sezione è in manutenzione. Se riscontri qualche problema, riprova più tardi",
+          "en-EN":
+            "The section is under maintenance. If you encounter any issues, please try again later."
+        }
+      }
+    ]
   },
   "sections": {
     "email_validation": {


### PR DESCRIPTION
## Short description
This PR enables a warning banner with a text about a **long** maintenance on the CGN screens: CGN_CATEGORIES and CGN_MERCHANTS_ALL

## List of changes proposed in this pull request
- Added a status message of warning level to the routes CGN_CATEGORIES and CGN_MERCHANTS_ALL..
