### PR TITLE
change azcopy version from 10.24.0 to 10.27.0

### DIFF
--- a/.github/workflows/publish_cdn.yml
+++ b/.github/workflows/publish_cdn.yml
@@ -53,7 +53,7 @@ jobs:
         uses: azure/CLI@ce5a2f60a82a531970a546cb97b6bf93b64fb9d3
         with:
           inlineScript: |
-            tdnf install -y azcopy-10.24.0
+            tdnf install -y azcopy-10.27.0
             # workaround to escape dollar sign
             container='$web'
 


### PR DESCRIPTION
## Short description
In order to resolve the problems on publish in this PR, as suggested by @Krusty93, I have updated the version of azcopy from 10.24.0 to 10.27.0
