### PR TITLE
chore: [PE-863] Removed CGN status banner

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -184,18 +184,7 @@
     }
   },
   "statusMessages": {
-    "items": [
-      {
-        "routes": ["CGN_CATEGORIES", "CGN_CATEGORIES_ALL"],
-        "level": "warning",
-        "message": {
-          "it-IT":
-            "La sezione è in manutenzione, alcuni partner torneranno operativi a breve.",
-          "en-EN":
-            "The section is under maintenance; some partners will resume service shortly."
-        }
-      }
-    ]
+    "items": []
   },
   "sections": {
     "email_validation": {


### PR DESCRIPTION
## Short description
This PR removes the CGN status banner showed inside the `CGN_CATEGORIES` screen

## List of changes proposed in this pull request
- Removed the items inside the status message array.
