### PR TITLE
[IOCOM-2071] Flag for disabling IOMarkdown remotely

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -523,6 +523,8 @@ definitions:
         $ref: "#/definitions/CieIDConfig"
       landing_banners:
         $ref: "#/definitions/LandingBannersConfig"
+      ioMarkdown:
+        $ref: "#/definitions/IOMarkdownConfig"
   BpdConfig:
     type: object
     description: A specific config for BPD bonus
@@ -1086,3 +1088,10 @@ definitions:
         type: array
         items:
           type: string
+  IOMarkdownConfig:
+    type: object
+    description: "A list fo settings to remotly handle the new markdown component"
+    properties:
+      disabledForMessagesAndServices:
+        description: "This property disables the use of IOMarkdown in rendering the message and service details, using the old component instead"
+        type: boolean

--- a/status/backend.json
+++ b/status/backend.json
@@ -181,6 +181,9 @@
         "ITW_DISCOVERY",
         "SETTINGS_DISCOVERY"
       ]
+    },
+    "ioMarkdown": {
+      "disabledForMessagesAndServices": false
     }
   },
   "statusMessages": {


### PR DESCRIPTION
## Short description
This PR adds an optional flag to disable the use of IOMarkdown in message and service details

## List of changes proposed in this pull request
- optional ioMarkdown section with optional proprerty

## How to test
CI should succeed
