### PR TITLE
[IOPID-2684] Bump `min_app_version` from `2.78.0.11` to `2.81.0.8`

### DIFF
--- a/status/versionInfo.json
+++ b/status/versionInfo.json
@@ -1,7 +1,7 @@
 {
   "min_app_version": {
-    "ios": "2.78.0.11",
-    "android": "2.78.0.11"
+    "ios": "2.81.0.8",
+    "android": "2.81.0.8"
   },
   "min_app_version_pagopa": {
     "ios": "0.0.0",


### PR DESCRIPTION
> [!NOTE]
> The merge of this PR is scheduled for **February 7, 2025**

## Short description
This PR bumps the min app version required to run the IO App. 

## List of changes proposed in this pull request
- Bumped `min_app_version` from `2.78.0.11` to `2.81.0.8`

## How to test
Static checks should pass
