### PR TITLE
[IOPID-2756] Change Banners priority order

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -183,9 +183,8 @@
     "landing_banners": {
       "priority_order": [
         "PUSH_NOTIFICATIONS_REMINDER",
-        "LV_EXPIRATION_REMINDER",
         "ITW_DISCOVERY",
-        "SETTINGS_DISCOVERY"
+        "LV_EXPIRATION_REMINDER"
       ]
     },
     "app_feedback": {


### PR DESCRIPTION
## Short description
This PR changes the `landing_banners` priority order and remove the `SETTINGS_DISCOVERY` identifier
