### PR TITLE
ci: [IOAPPX-483] Update `actions/cache` due to GitHub deprecation

### DIFF
--- a/.github/workflows/static-checks.yml
+++ b/.github/workflows/static-checks.yml
@@ -17,7 +17,7 @@ jobs:
         run: echo "dir=$(yarn cache dir)" >> $GITHUB_OUTPUT
         shell: bash
       - id: yarn-cache
-        uses: actions/cache@88522ab9f39a2ea568f7027eddc7d8d8bc9d59c8 # v3.3.1
+        uses: actions/cache@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
         env:
           cache-name: cache-node-modules
         with:


### PR DESCRIPTION
## Short description

This PR updates the `actions/cache` from version `v3.3.1` (deprecated) to `v4.2.0`