### PR TITLE
chore: IOMarkdown enabled on 3.1.0.0+

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -208,8 +208,8 @@
     },
     "ioMarkdown": {
       "min_app_version": {
-        "ios": "0.0.0.0",
-        "android": "0.0.0.0"
+        "ios": "3.1.0.0",
+        "android": "3.1.0.0"
       }
     }
   },


### PR DESCRIPTION
## Short description
This PR enables IOMarkdown for IO-App versions 3.1.0.0+

## List of changes proposed in this pull request
- min_app_version set to 3.1.0.0

## How to test
CI should succeed.
