### PR TITLE
chore: min app version 3.2.0.0 for IOMarkdown

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -212,8 +212,8 @@
     },
     "ioMarkdown": {
       "min_app_version": {
-        "ios": "3.1.0.0",
-        "android": "3.1.0.0"
+        "ios": "3.2.0.0",
+        "android": "3.2.0.0"
       }
     }
   },


### PR DESCRIPTION
## Short description
This PR sets 3.2.0.0 as the min app version for IOMarkdown
