### PR TITLE
chore: enables IOMarkdown from 3.3.0.0

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -212,8 +212,8 @@
     },
     "ioMarkdown": {
       "min_app_version": {
-        "ios": "3.2.0.0",
-        "android": "3.2.0.0"
+        "ios": "3.3.0.0",
+        "android": "3.3.0.0"
       }
     }
   },


### PR DESCRIPTION
## Short description
This PR disables IOMarkdown (messages/services) for IO App versions lower than 3.3.0.0
