### PR TITLE
Revert "chore: disable iPatente CTA in MDL credential details screen"

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -177,7 +177,7 @@
       "feedback_banner_visible": true,
       "ipatente_cta_visible": true,
       "ipatente_cta_config": {
-        "visibility": false,
+        "visibility": true,
         "url": "https://licences.ipatente.io.pagopa.it/licences",
         "service_id": "01JEXVQSRV2XRX9XDWQ5XQ6A8T",
         "service_name": "Motorizzazione Civile - Le mie patenti",


### PR DESCRIPTION
Reverts pagopa/io-services-metadata#930