### PR TITLE
feat: [IOBP-1562] Add `pspBanner` property and definitions

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -938,6 +938,11 @@ definitions:
       feedbackBanner:
         $ref: "#/definitions/Banner"
         description: "If provided a feedback banner will be shown in the payment success screen"
+      pspBanner:
+        type: object
+        description: "A map where keys are payment method shortname and values are the Banner objects"
+        additionalProperties:
+          $ref: "#/definitions/Banner"
   PnConfig:
     type: object
     description: "A configuration for the PN feature"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.59",
+  "version": "1.0.60",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -108,6 +108,22 @@
           },
           "url": "https://pagopa.qualtrics.com/jfe/form/SV_0GmGr2F3vt8oaZE"
         }
+      },
+      "pspBanner": {
+        "MYBANK": {
+          "min_app_version": {
+            "ios": "2.65.0.0",
+            "android": "2.65.0.0"
+          },
+          "title": {
+            "it-IT": "Non trovi la tua banca?",
+            "en-EN":  "You don't find your bank?"
+          },
+          "description": {
+            "it-IT": "Non preoccuparti: dovrai selezionarla nei passaggi successivi.",
+            "en-EN": "Don't worry: you will have to select it in the next steps."
+          }
+        }
       }
     },
     "lollipop": {


### PR DESCRIPTION
## Short description
This PR adds the `pspBanner` props and definitions. The goal of this remote configuration is to show/hide a banner inside the PSP selection screen based on the payment method selected by the user.

## List of changes proposed in this pull request
- Defined the `pspBanner` with a key-value object where the keys are the payment method short name and the values are Banner object type to show/hide a banner;
