### PR TITLE
chore: [IOBP-1419] Cdc min app version feature flag

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -458,6 +458,7 @@ definitions:
       - fims
       - premiumMessages
       - cdc
+      - cdcV2
       - barcodesScanner
       - fci
       - idPay

--- a/definitions.yml
+++ b/definitions.yml
@@ -497,6 +497,8 @@ definitions:
         $ref: "#/definitions/PremiumMessagesConfig"
       cdc:
         $ref: "#/definitions/CdcConfig"
+      cdcV2:
+        $ref: "#/definitions/CdcConfigV2"
       barcodesScanner:
         $ref: "#/definitions/BarcodesScannerConfig"
       fci:
@@ -851,6 +853,15 @@ definitions:
       enabled:
         type: boolean
         description: "If true, are visible the entry points: bonus menu, carousel, service page cta, and message cta"
+  CdcConfigV2:
+    type: object
+    description: "A configuration for the carta della cultura feature"
+    required:
+      - min_app_version
+    properties:
+      min_app_version:
+        $ref: "#/definitions/VersionPerPlatform"
+        description: "If min app version supported, are visible the entry points: bonus menu, carousel, service page cta, and message cta"
   BarcodesScannerConfig:
     type: object
     description: "A configuration for the barcodes scanner in the payment section"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.61",
+  "version": "1.0.67",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.60",
+  "version": "1.0.61",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -63,6 +63,12 @@
     "cdc": {
       "enabled": false
     },
+    "cdcV2": {
+      "min_app_version": {
+        "ios": "4.0.0.0",
+        "android": "4.0.0.0"
+      }
+    },
     "barcodesScanner": {
       "dataMatrixPosteEnabled": true
     },


### PR DESCRIPTION
## Short description
This pull request introduces a new configuration for CDC called `cdcV2` since we cannot edit `cdc` property without causing IO app crash

## List of changes proposed in this pull request
- `cdcV2` reference under `definitions` and defined the `CdcConfigV2` object with its properties.
- Added the `cdcV2` configuration with the `min_app_version` property for both iOS and Android platforms.

## How to test
N/A
