### PR TITLE
chore: enable IOMarkdown from 3.1.0.0

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -240,8 +240,8 @@
     },
     "ioMarkdown": {
       "min_app_version": {
-        "ios": "3.5.0.0",
-        "android": "3.5.0.0"
+        "ios": "3.1.0.0",
+        "android": "3.1.0.0"
       }
     }
   },


### PR DESCRIPTION
## Short description
This PR enabled IOMarkdown in production, starting from IOApp version 3.1.0.0.

## List of changes proposed in this pull request
- Feature A
- Feature B

## How to test
Describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
