### PR TITLE
chore: Enable `webViewPaymentFlow` from the v. `3.6.0.1`

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -137,8 +137,8 @@
       },
       "webViewPaymentFlow": {
         "min_app_version": {
-          "ios": "5.0.0.0",
-          "android": "5.0.0.0"
+          "ios": "3.6.0.1",
+          "android": "3.6.0.1"
         }
       }
     },


### PR DESCRIPTION
## Short description
This PR enables the webview payment flow from the version `3.6.0.1` that is currently in Beta

## List of changes proposed in this pull request
- Set the version to the `webViewPaymentFlow` attribute to the value `3.6.0.1`;

## How to test
- Open the app IO with version `3.6.0.1` in Beta and check that the flow is started within a webview instead of the in-app browser when you start a new payment.
