### PR TITLE
chore: Enable payment webview flow

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -146,8 +146,8 @@
       },
       "webViewPaymentFlow": {
         "min_app_version": {
-          "ios": "5.0.0.0",
-          "android": "5.0.0.0"
+          "ios": "3.6.0.9",
+          "android": "3.6.0.9"
         }
       }
     },


### PR DESCRIPTION
## Short description
This PR enables the webview payment flow on version `3.6.0.9` both on iOS and Android