### PR TITLE
feat: [IOCOM-2458] SEND AAR QRcode Regex

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -1033,6 +1033,9 @@ definitions:
       privacy_url:
         type: string
         description: 'the privacy informative URL'
+      aarQRCodeRegex:
+        type: string
+        description: 'A regex to match the content of an "Avviso Avvenuta Ricezione" QRCode'
   PaymentsConfig:
     type: object
     description: "Configuration data related to payments"

--- a/status/backend.json
+++ b/status/backend.json
@@ -219,7 +219,8 @@
       "optInServiceId": "01G74SW1PSM6XY2HM5EGZHZZET",
       "notificationServiceId": "01G40DWQGKY5GRWSNM4303VNRP",
       "tos_url": "https://cittadini.notifichedigitali.it/termini-di-servizio",
-      "privacy_url": "https://cittadini.notifichedigitali.it/informativa-privacy"
+      "privacy_url": "https://cittadini.notifichedigitali.it/informativa-privacy",
+      "aarQRCodeRegex": "^\\s*https:\\/\\/(dev\\.|test\\.|hotfix\\.|uat\\.)?cittadini\\.notifichedigitali\\.it(\\/[^?]*)?\\?aar=.+\\s*"
     },
     "payments": {
       "preferredPspsByOrigin": {

--- a/status/backend.json
+++ b/status/backend.json
@@ -220,7 +220,7 @@
       "notificationServiceId": "01G40DWQGKY5GRWSNM4303VNRP",
       "tos_url": "https://cittadini.notifichedigitali.it/termini-di-servizio",
       "privacy_url": "https://cittadini.notifichedigitali.it/informativa-privacy",
-      "aarQRCodeRegex": "^\\s*https:\\/\\/(dev\\.|test\\.|hotfix\\.|uat\\.)?cittadini\\.notifichedigitali\\.it(\\/[^?]*)?\\?aar=.+\\s*"
+      "aarQRCodeRegex": "^\\s*https:\\/\\/(dev\\.|test\\.|hotfix\\.|uat\\.)?cittadini\\.notifichedigitali\\.it(\\/[^?]*)?\\?aar=[^\\s]+"
     },
     "payments": {
       "preferredPspsByOrigin": {


### PR DESCRIPTION
## Short description
This PR adds a (javascript-like) regex that matches AAR QRCode (SEND), for every known environment.

## List of changes proposed in this pull request
- Matched urls are in case-insensitive format 
`https://[dev.|test.|hotfix.|uat.|]cittadini.notifichedigitali.it/[paths/]?aar=anyValue`
with any leading and/or trailing spaces

## How to test
Check that the following urls are matched when the regex is used in a javascript environment:
```
https://dev.cittadini.notifichedigitali.it/?aar=xyz123
https://test.cittadini.notifichedigitali.it/?aar=xyz123
https://hotfix.cittadini.notifichedigitali.it/?aar=xyz123
https://uat.cittadini.notifichedigitali.it/?aar=xyz123
https://cittadini.notifichedigitali.it/?aar=xyz123
https://cittadini.notifichedigitali.it/notifications/detail?aar=xyz123
  https://dev.cittadini.notifichedigitali.it/some/path?aar=xyz123        // This url has both leading and trailing spaces
```
and the following urls are not matched
```
https://cittadini.notifichedigitali.it/?aar=               // empty aar value
https://other-domain.it/?aar=whatever                      // wrong domain
https://stage.cittadini.notifichedigitali.it/?aar=xyz123   // unknown subdomain
```