### PR TITLE
chore: [IOBP-1874] Add banner status message `label_cta` property

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -355,6 +355,8 @@ definitions:
         $ref: "#/definitions/BackendStatusMessage"
       message:
         $ref: "#/definitions/BackendStatusMessage"
+      label_cta:
+        $ref: "#/definitions/BackendStatusMessage"
   Sections:
     type: object
     description: The status of the app sections

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.0.74",
+  "version": "1.0.76",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",


### PR DESCRIPTION
## Short description
This PR adds to the `definitions.yml` a new `label_cta` field to the `StatusMessage` definition, allowing it to be set remotely.

## List of changes proposed in this pull request
- Added `label_cta` property to the `StatusMessage` definition.
