### PR TITLE
chore: [IOBP-1930] Enable CGN status banner short maintenance

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -287,7 +287,18 @@
     }
   },
   "statusMessages": {
-    "items": []
+    "items": [
+      {
+        "routes": ["CGN_MERCHANTS_CATEGORIES", "CGN_MERCHANTS_LIST_BY_CATEGORY"],
+        "level": "warning",
+        "message": {
+          "it-IT":
+            "La sezione è in manutenzione, alcuni partner torneranno operativi a breve.",
+          "en-EN":
+            "The section is under maintenance; some partners will resume service shortly."
+        }
+      }
+    ]
   },
   "sections": {
     "email_validation": {


### PR DESCRIPTION
# 🕦 Scheduled merge on 17th August 2025 at 2:00 PM

## Short description
This PR enables a warning banner with a text about a **short** maintenance on the CGN screens: `CGN_MERCHANTS_CATEGORIES` and `CGN_MERCHANTS_LIST_BY_CATEGORY`

## List of changes proposed in this pull request
- Added a status message of warning level to the routes `CGN_MERCHANTS_CATEGORIES` and `CGN_MERCHANTS_LIST_BY_CATEGORY`..
