### PR TITLE
chore: [IOPID-3364] add maintenance banner on landing and email verification screens 

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -297,7 +297,32 @@
     }
   },
   "statusMessages": {
-    "items": []
+    "items": [
+      {
+        "routes": ["AUTHENTICATION_LANDING"],
+        "level": "warning",
+        "message": {
+          "it-IT":
+            "L'app non sarà accessibile dalle 6:00 del 4 settembre. Ci vediamo dopo le 8:00!",
+          "en-EN":
+            "L'app non sarà accessibile dalle 6:00 del 4 settembre. Ci vediamo dopo le 8:00!"
+        }
+      },
+      {
+        "routes": [
+          "ONBOARDING_EMAIL_VERIFICATION_SCREEN",
+          "INSERT_EMAIL_SCREEN",
+          "EMAIL_VERIFICATION_SCREEN"
+        ],
+        "level": "warning",
+        "message": {
+          "it-IT":
+            "Per lavori tecnici dalle 6:00 alle 8:00 del 4 settembre non riusciremo a inviare email. Modifica l’email dopo le 8:00.",
+          "en-EN":
+            "Per lavori tecnici dalle 6:00 alle 8:00 del 4 settembre non riusciremo a inviare email. Modifica l’email dopo le 8:00."
+        }
+      }
+    ]
   },
   "sections": {
     "email_validation": {


### PR DESCRIPTION
> [!Warning]
> English translations are missing, they will be added shortly

## Short description
This PR enables the maintenance status banner on landing and email verification screens (it will be activated in the late afternoon of Wednesday, September 3, and will be removed at 8 a.m. on September 4).

## Demo (realized using the dev-server)

https://github.com/user-attachments/assets/f9e64d30-f115-49f1-8175-8c1e35324d92


