### PR TITLE
feat: [IOBP-1963] Remote CaC banner config

### DIFF
--- a/assistanceTools/zendesk.json
+++ b/assistanceTools/zendesk.json
@@ -56,9 +56,9 @@
                 "de-DE": "Mehr lesen"
               },
               "href": {
-                "it-IT":"https://assistenza.ioapp.it/hc/it",
-                "en-EN":"https://assistenza.ioapp.it/hc/it",
-                "de-DE":"https://assistenza.ioapp.it/hc/it"
+                "it-IT": "https://assistenza.ioapp.it/hc/it",
+                "en-EN": "https://assistenza.ioapp.it/hc/it",
+                "de-DE": "https://assistenza.ioapp.it/hc/it"
               }
             }
           }
@@ -460,5 +460,29 @@
         }
       }
     ]
+  },
+  "zendeskCacBanner": {
+    "title": {
+      "it-IT": "Serve aiuto?",
+      "en-EN": "Serve aiuto?",
+      "de-DE": "Serve aiuto?"
+    },
+    "content": {
+      "it-IT": "Abbiamo preparato una guida per aiutarti a risolvere velocemente il tuo problema.",
+      "en-EN": "Abbiamo preparato una guida per aiutarti a risolvere velocemente il tuo problema.",
+      "de-DE": "Abbiamo preparato una guida per aiutarti a risolvere velocemente il tuo problema."
+    },
+    "action": {
+      "label": {
+        "it-IT": "Vai al Centro assistenza",
+        "en-EN": "Vai al Centro assistenza",
+        "de-DE": "Vai al Centro assistenza"
+      },
+      "href": {
+        "it-IT": "https://assistenza.ioapp.it/hc/it",
+        "en-EN": "https://assistenza.ioapp.it/hc/it",
+        "de-DE": "https://assistenza.ioapp.it/hc/it"
+      }
+    }
   }
 }

--- a/definitions.yml
+++ b/definitions.yml
@@ -650,6 +650,11 @@ definitions:
         description: "If true is not possible open a ticket"
       zendeskCategories:
         $ref: "#/definitions/ZendeskCategories"
+      zendeskCacBanner:
+        type: object
+        description: "Zendesk CaC banner configuration that can be shown in the Help Center screen"
+        additionalProperties:
+          $ref: "#/definitions/Banner"
   ZendeskCategories:
     type: object
     description: "Map the id and the categories created in Zendesk"


### PR DESCRIPTION
## Short description
This pull request introduces a new configuration for displaying a Zendesk CaC (Customer Assistance Center) banner in the Help Center screen

## List of changes proposed in this pull request
- Updated `definitions.yml` to include a `zendeskCacBanner` object in the Zendesk configuration, referencing a `Banner` definition for its properties.

## How to test
Ensure that all checks are passing