### PR TITLE
[IOCOM-2575] SEND AAR QR CODE regex update

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -224,7 +224,7 @@
       "notificationServiceId": "01G40DWQGKY5GRWSNM4303VNRP",
       "tos_url": "https://cittadini.notifichedigitali.it/termini-di-servizio",
       "privacy_url": "https://cittadini.notifichedigitali.it/informativa-privacy",
-      "aarQRCodeRegex": "^\\s*https:\\/\\/(dev\\.|test\\.|hotfix\\.|uat\\.)?(cittadini|login)\\.notifichedigitali\\.it(\\/[^?]*)?\\?aar=[^\\s]+",
+      "aarQRCodeRegex":"^\\s*https:\\/\\/(cittadini|login)\\.(uat\\.)?notifichedigitali\\.it(\\/[^?]*)?\\?aar=[^\\s]+",
       "aar": {
         "min_app_version": {
           "ios": "3.13.0.0",


### PR DESCRIPTION
## Short description
update of said regEx

## List of changes proposed in this pull request
updated said regex to only match "uat" and production URLs, and moved the "uat" subdmain from first to second place, as per specifications.
## How to test
automated tests should pass, also test the given regex on any JS engine (such as the browser's console) like this:

```
const a = new RegExp(aarQRCodeRegexString, "i")),
const result = a.test(data)
```
and with those strings:
```
---- passing cases ---------

"https://cittadini.notifichedigitali.it/io?aar=test" 
https://cittadini.uat.notifichedigitali.it/io?aar=test" 
"https://login.notifichedigitali.it/io?aar=test"
"https:/login.uat.notifichedigitali.it/io?aar=test" 
"             https://cittadini.notifichedigitali.it/io?aar=test" 
"             https://cittadini.notifichedigitali.it/io?aar=test            " 
"https://cittadini.notifichedigitali.it/io?aar=test            "

--- failing cases ----
"https://cittadini.notifichedigitali.it/io?aar=" 
"http://cittadini.notifichedigitali.it/io?aar=12314" 
"ANY_NON_WHITESPACE_CHAR https://cittadini.notifichedigitali.it/io?aar=12314" 
"https://cittadini.dev.notifichedigitali.it/io?aar=12314" 
"https://cittadini.notifichedigitali.it/io" 
"https://uat.cittadini.notifichedigitali.it/io?aar=12314" 
 ```
