### PR TITLE
refactor: [IOPID-2649] Remove cieid ff occurrences from `definitions.yml` and form `backend.json`

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -528,8 +528,6 @@ definitions:
         $ref: "#/definitions/AbsolutePortalLinksConfig"
       itw:
         $ref: "#/definitions/ItwConfig"
-      cie_id:
-        $ref: "#/definitions/CieIDConfig"
       landing_banners:
         $ref: "#/definitions/LandingBannersConfig"
       app_feedback:
@@ -1241,13 +1239,6 @@ definitions:
       de-DE:
         type: string
         pattern: "^https://"
-  CieIDConfig:
-    type: object
-    description: "A configuration for the CieID feature"
-    properties:
-      min_app_version:
-        $ref: "#/definitions/VersionPerPlatform"
-        description: "If min app version supported, the user can see the login with CieID section"
   LandingBannersConfig:
     type: object
     description: "A FIFO list of banner IDs to render in the landing screen. Visibility rules must be set and processed in app"

--- a/status/backend.json
+++ b/status/backend.json
@@ -264,12 +264,6 @@
         "service_organization_fiscal_code": "97532760580"
       }
     },
-    "cie_id": {
-      "min_app_version": {
-        "ios": "2.78.0.11",
-        "android": "2.78.0.11"
-      }
-    },
     "landing_banners": {
       "priority_order": [
         "PUSH_NOTIFICATIONS_REMINDER",


### PR DESCRIPTION
## Short description
This PR removes all the occurrences related to the `cie_id` FF from the `definitions.yml` and from the `backend.json` files

## How to test
It can be tested from the following PRs:
- https://github.com/pagopa/io-dev-api-server/pull/537
- https://github.com/pagopa/io-app/pull/7357
