### PR TITLE
chore(IT-Wallet): [SIW-4063] Add warning message for digital document functionality maintenance

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -439,6 +439,16 @@
           "it-IT":
             "https://ioapp.it/scarica-io"
         }
+      },
+      {
+        "routes": ["WALLET_HOME", "ITW_DISCOVERY_INFO"],
+        "level": "warning",
+        "message": {
+          "it-IT":
+          "Le funzionalità dei documenti digitali potrebbero non essere disponibili per manutenzione programmata.",
+          "en-EN":
+          "Le funzionalità dei documenti digitali potrebbero non essere disponibili per manutenzione programmata."
+        }
       }
     ]
   },


### PR DESCRIPTION
This pull request adds a new warning message to the backend configuration to inform users about potential unavailability of digital document features due to scheduled maintenance. The warning is displayed on both the `WALLET_HOME` and `ITW_DISCOVERY_INFO` routes