### PR TITLE
feat: add pinned_credentials and new_credentials to definitions and backend status

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -1289,6 +1289,11 @@ definitions:
       ipzs_privacy_url:
         type: string
         description: "The URL to the IPZS privacy policy"
+      pinned_credentials:
+        type: array
+        description: "List of credentials to pin in the credentials selection screen"
+        items:
+          type: string
   Banner:
     type: object
     required:

--- a/definitions.yml
+++ b/definitions.yml
@@ -1299,6 +1299,11 @@ definitions:
         description: "List of credentials to be highlighted as new in the credentials catalogue"
         items:
           type: string
+      hidden_credentials:
+        type: array
+        description: "List of credentials to be hidden in the credentials catalogue"
+        items:
+          type: string
   Banner:
     type: object
     required:

--- a/definitions.yml
+++ b/definitions.yml
@@ -1294,6 +1294,11 @@ definitions:
         description: "List of credentials to pin in the credentials selection screen"
         items:
           type: string
+      new_credentials:
+        type: array
+        description: "List of credentials to be highlighted as new in the credentials catalogue"
+        items:
+          type: string
   Banner:
     type: object
     required:

--- a/status/backend.json
+++ b/status/backend.json
@@ -382,7 +382,8 @@
         "service_organization_name": "Ministero delle infrastrutture e dei trasporti",
         "service_organization_fiscal_code": "97532760580"
       },
-      "ipzs_privacy_url": "https://util.wallet.ipzs.it/privacy.html"
+      "ipzs_privacy_url": "https://util.wallet.ipzs.it/privacy.html",
+      "pinned_credentials": ["ITW_PG_V3", "ITW_TS_V3"]
     },
     "landing_banners": {
       "priority_order": [

--- a/status/backend.json
+++ b/status/backend.json
@@ -383,8 +383,9 @@
         "service_organization_fiscal_code": "97532760580"
       },
       "ipzs_privacy_url": "https://util.wallet.ipzs.it/privacy.html",
-      "pinned_credentials": ["ITW_PG_V3", "ITW_TS_V3"],
-      "new_credentials": ["ITW_EDIP", "ITW_EDAT"]
+      "pinned_credentials": ["mDL", "EuropeanHealthInsuranceCard"],
+      "new_credentials": ["education_degree", "education_enrollment", "education_diploma", "education_attendance"],
+      "hidden_credentials": ["age_verification"]
     },
     "landing_banners": {
       "priority_order": [

--- a/status/backend.json
+++ b/status/backend.json
@@ -383,7 +383,8 @@
         "service_organization_fiscal_code": "97532760580"
       },
       "ipzs_privacy_url": "https://util.wallet.ipzs.it/privacy.html",
-      "pinned_credentials": ["ITW_PG_V3", "ITW_TS_V3"]
+      "pinned_credentials": ["ITW_PG_V3", "ITW_TS_V3"],
+      "new_credentials": ["ITW_EDIP", "ITW_EDAT"]
     },
     "landing_banners": {
       "priority_order": [


### PR DESCRIPTION
## Short description
Add `pinned_credentials`, `new_credentials` and `hidden_credentials` fields to `ItwConfig` to support pinning and highlight as new specific credentials in the credential selection screen of the IT Wallet.

  ## List of changes proposed in this pull request
- Added `pinned_credentials`, `new_credentials` and `hidden_credentials` array definitions to `ItwConfig` in `definitions.yml`
- Populated `pinned_credentials` with `["mDL", "EuropeanHealthInsuranceCard"]` in `status/backend.json`
- Populated `new_credentials` with `["education_degree", "education_enrollment", "education_diploma", "education_attendance"]` in `status/backend.json`
-  Populated `hidden_credentials` with `["age_verification"]` in `status/backend.json`

## How to test
1. Verify the `definitions.yml` schema is valid and the new `pinned_credentials`, `new_credentials` and `hidden_credentials` properties appear under `ItwConfig` with `type: array` and `items: type: string`
2. Check that `status/backend.json` contains the `pinned_credentials`, `new_credentials` and `hidden_credentials` fields inside the `itw` config block.