### PR TITLE
chore: [IOCOM-3171] configuration for the messages' feedback banner

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -534,6 +534,8 @@ definitions:
         $ref: "#/definitions/LandingBannersConfig"
       app_feedback:
         $ref: "#/definitions/AppFeedbackConfig"
+      messages_feedback_banner:
+        $ref: "#/definitions/MessagesFeedbackBannerConfig"
       ioMarkdown:
         $ref: "#/definitions/IOMarkdownConfig"
       services:
@@ -1403,6 +1405,19 @@ definitions:
       feedback_uri:
         $ref: "#/definitions/AppFeedbackUri"
         description: "The config of uri to be used in app divided by topic and default one"
+  MessagesFeedbackBannerConfig:
+    type: object
+    description: "A configuration for the messages' feedback banner"
+    required:
+      - min_app_version
+      - feedback_uri
+    properties:
+      min_app_version:
+        $ref: "#/definitions/VersionPerPlatform"
+        description: "If min app version supported, the user can send feedback about messages"
+      feedback_uri:
+        type: string
+        description: "The uri to be invoked to let the user share feedback via the messages' survey banner"
   IOMarkdownConfig:
     type: object
     description: "A list of settings to remotely handle the new markdown component"

--- a/definitions.yml
+++ b/definitions.yml
@@ -1408,9 +1408,6 @@ definitions:
   MessagesFeedbackBannerConfig:
     type: object
     description: "A configuration for the messages' feedback banner"
-    required:
-      - min_app_version
-      - feedback_uri
     properties:
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"

--- a/definitions.yml
+++ b/definitions.yml
@@ -1414,7 +1414,7 @@ definitions:
     properties:
       min_app_version:
         $ref: "#/definitions/VersionPerPlatform"
-        description: "If min app version supported, the user can send feedback about messages"
+        description: "If min app version is not met, the messages' feedback banner will not be rendered"
       feedback_uri:
         type: string
         description: "The uri to be invoked to let the user share feedback via the messages' survey banner"

--- a/status/backend.json
+++ b/status/backend.json
@@ -418,8 +418,8 @@
     },
     "messages_feedback_banner": {
       "min_app_version": {
-        "ios": "3.35.0.6",
-        "android": "3.35.0.6"
+        "ios": "4.0.0.0",
+        "android": "4.0.0.0"
       },
       "feedback_uri": "https://pagopa.qualtrics.com/jfe/form/SV_0VCZTkYbfozt9ki"
     },

--- a/status/backend.json
+++ b/status/backend.json
@@ -416,6 +416,13 @@
         "itw": "https://pagopa.qualtrics.com/jfe/form/SV_eVWKW6v4V6RikbY"
       }
     },
+    "messages_feedback_banner": {
+      "min_app_version": {
+        "ios": "3.35.0.6",
+        "android": "3.35.0.6"
+      },
+      "feedback_uri": "https://pagopa.qualtrics.com/jfe/form/SV_0VCZTkYbfozt9ki"
+    },
     "ioMarkdown": {
       "min_app_version": {
         "ios": "3.8.0.9",


### PR DESCRIPTION
## Short description
this PR includes baseUrl and min app version for the feedback banner to be shown in the messages' details

## List of changes proposed in this pull request
- base qualtrics url
- min app version
- updated definitions to match

## How to test
automated tests should pass