### PR TITLE
chore: [IOCOM-3247] messages feedback banner disable

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -418,8 +418,8 @@
     },
     "messages_feedback_banner": {
       "min_app_version": {
-        "ios": "3.35.0.10",
-        "android": "3.35.0.10"
+        "ios": "0.0.0.0",
+        "android": "0.0.0.0"
       },
       "feedback_uri": "https://pagopa.qualtrics.com/jfe/form/SV_0VCZTkYbfozt9ki"
     },


### PR DESCRIPTION
## Short description
this Pr disables the messages' feedback banner in io-app via minimum version FF.

## List of changes proposed in this pull request
- updated min version tag for both android and iOS

## How to test
automated tests should pass
