### PR TITLE
chore(IT-Wallet): [SIW-4604] clear new_credentials and hidden_credentials arrays in backend configuration

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -384,8 +384,8 @@
       },
       "ipzs_privacy_url": "https://util.wallet.ipzs.it/privacy.html",
       "pinned_credentials": ["mDL", "EuropeanHealthInsuranceCard"],
-      "new_credentials": ["education_degree", "education_enrollment", "education_diploma", "education_attendance"],
-      "hidden_credentials": ["age_verification"],
+      "new_credentials": [],
+      "hidden_credentials": [],
       "itw_min_app_version": {
         "ios": "3.30.0.3",
         "android": "3.30.0.3"


### PR DESCRIPTION
## Short description
This PR clears the new_credentials and hidden_credentials arrays in status/backend.json, removing stale/no-longer-valid entries from the backend configuration.
