### PR TITLE
fix: [IOPID-000] Update OneIdentity feature rollout percentage constraints

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -1475,8 +1475,6 @@ definitions:
     properties:
       rolloutPercentage:
         type: number
-        minimum: 0
-        maximum: 100
         description: "The percentage of users that will be able to use the One Identity feature"
   FimsServiceConfiguration:
     type: object

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",


### PR DESCRIPTION
## Short description
This PR removes constraints on the `rolloutPercentage` property.

## List of changes proposed in this pull request
- Removed the `minimum` and `maximum` constraints from the `rolloutPercentage` property in `definitions.yml`
- Bumped the package version to `1.1.1`

## How to test
All checks have to be green
