### PR TITLE
feat: [IOPID-4116] Add One Identity idps url

### DIFF
--- a/definitions.yml
+++ b/definitions.yml
@@ -1489,7 +1489,6 @@ definitions:
       idpsUrl:
         type: string
         description: "The URL to retrieve the list of identity providers (IDPs)"
-        pattern: ^https://
   FimsServiceConfiguration:
     type: object
     description: "Service and organization properties of a service that can start the FIMS flow"

--- a/definitions.yml
+++ b/definitions.yml
@@ -1476,6 +1476,20 @@ definitions:
       rolloutPercentage:
         type: number
         description: "The percentage of users that will be able to use the One Identity feature"
+      environments:
+        type: object
+        properties:
+          prod:
+            $ref: "#/definitions/OneIdentityEnvironmentConfig"
+          uat:
+            $ref: "#/definitions/OneIdentityEnvironmentConfig"
+  OneIdentityEnvironmentConfig:
+    type: object
+    properties:
+      idpsUrl:
+        type: string
+        description: "The URL to retrieve the list of identity providers (IDPs)"
+        pattern: ^https://
   FimsServiceConfiguration:
     type: object
     description: "Service and organization properties of a service that can start the FIMS flow"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "italia-services-metadata",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Services metadata",
   "main": "src/index.ts",
   "repository": "git@github.com:pagopa/io-services-metadata.git",

--- a/status/backend.json
+++ b/status/backend.json
@@ -309,7 +309,7 @@
           "idpsUrl": "https://io.oneid.pagopa.it/idps"
         },
         "uat": {
-          "idpsUrl": "https://io.uat.oneid.pagopa.it/idps"
+          "idpsUrl": "https://uat.io.oneid.pagopa.it/idps"
         }
       }
     },

--- a/status/backend.json
+++ b/status/backend.json
@@ -303,7 +303,15 @@
       "loginUrl": "https://app-backend.io.italia.it"
     },
     "oneIdentity": {
-      "rolloutPercentage": 0
+      "rolloutPercentage": 0,
+      "environments": {
+        "prod": {
+          "idpsUrl": "https://io.oneid.pagopa.it/idps"
+        },
+        "uat": {
+          "idpsUrl": "https://io.uat.oneid.pagopa.it/idps"
+        }
+      }
     },
     "pn": {
       "enabled": true,


### PR DESCRIPTION
## Short description
This PR introduces an `environments` object within the `oneIdentityConfig` to manage environment-specific data. Specifically, it defines the URL used to retrieve the list of Identity Providers (IdPs) for each environment.

## How to test
All checks have to be green
