### PR TITLE
Feat/backend status banner 12 aug

### DIFF
--- a/status/backend.json
+++ b/status/backend.json
@@ -533,6 +533,15 @@
           "it-IT":
             "https://ioapp.it/scarica-io"
         }
+      },{
+        "routes": [
+          "AUTHENTICATION_LANDING"
+        ],
+        "level": "warning",
+        "message": {
+          "it-IT": "L'app non sarà accessibile dalle 7:00 del 12 agosto. Ci vediamo dopo le 9:00!",
+          "en-EN": "The app will be unavailable from 7:00 to 9:00 on 12 August. See you after 9:00!"
+        }
       }
     ]
   },

--- a/status/backend.json
+++ b/status/backend.json
@@ -533,7 +533,8 @@
           "it-IT":
             "https://ioapp.it/scarica-io"
         }
-      },{
+      },
+      {
         "routes": [
           "AUTHENTICATION_LANDING"
         ],
@@ -541,6 +542,18 @@
         "message": {
           "it-IT": "L'app non sarà accessibile dalle 7:00 del 12 agosto. Ci vediamo dopo le 9:00!",
           "en-EN": "The app will be unavailable from 7:00 to 9:00 on 12 August. See you after 9:00!"
+        }
+      },
+      {
+        "routes": [
+          "ONBOARDING_EMAIL_VERIFICATION_SCREEN", 
+          "INSERT_EMAIL_SCREEN", 
+          "EMAIL_VERIFICATION_SCREEN" 
+        ],
+        "level": "warning",
+        "message": {
+          "it-IT": "Per lavori tecnici dalle 7:00 alle 9:00 del 12 agosto non riusciremo a inviare email. Modifica l’email dopo le 9:00.",
+          "en-EN": "Due to technical work from 7:00 to 9:00 on 12 August, we won't be able to send emails. Please change your email after 9:00."
         }
       }
     ]


### PR DESCRIPTION
## Description
Adds in-app banners to inform users about scheduled maintenance on 12 August (7:00–9:00), during which the app will be unavailable and email sending will not work.

## List of changes proposed in this pull request
- Added a `warning` level banner for the `AUTHENTICATION_LANDING` route, informing users the app will be unavailable from 7:00 to 9:00 on 12 August (it-IT / en-EN)
- Added a `warning` level banner for the `ONBOARDING_EMAIL_VERIFICATION_SCREEN`, `INSERT_EMAIL_SCREEN` and `EMAIL_VERIFICATION_SCREEN` routes, informing users that email sending will be unavailable from 7:00 to 9:00 on 12 August (it-IT / en-EN)

## How to test
1. Point the IO app status source to this branch's `status/backend.json`
2. Open the app on the `AUTHENTICATION_LANDING` route and verify the maintenance banner is shown in it-IT and en-EN
3. Open the app on the email verification/insertion screens and verify the email-sending banner is shown in it-IT and en-EN
